### PR TITLE
Fix duplicate state init

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@manuscripts/body-editor",
   "description": "Prosemirror components for editing and viewing manuscripts",
-  "version": "1.6.5",
+  "version": "1.6.6",
   "repository": "github:Atypon-OpenSource/manuscripts-body-editor",
   "license": "Apache-2.0",
   "main": "dist/cjs",

--- a/src/configs/ManuscriptsEditor.ts
+++ b/src/configs/ManuscriptsEditor.ts
@@ -35,9 +35,9 @@ import React from 'react'
 import { DefaultTheme } from 'styled-components'
 
 import { CollabProvider } from '../classes/collabProvider'
+import { Dispatch } from '../commands'
 import { transformPasted } from '../lib/paste'
 import { PopperManager } from '../lib/popper'
-import { CreateView } from '../useEditor'
 import plugins from './editor-plugins'
 import views from './editor-views'
 
@@ -81,30 +81,30 @@ export interface EditorProps {
   collabProvider?: CollabProvider
 }
 
-export default {
-  createState: (props: EditorProps) => {
-    return EditorState.create({
-      doc: props.doc,
-      schema,
-      plugins: plugins(props),
-    })
-  },
+export const createEditorState = (props: EditorProps) =>
+  EditorState.create({
+    doc: props.doc,
+    schema,
+    plugins: plugins(props),
+  })
 
-  createView:
-    (props: EditorProps): CreateView =>
-    (el, state, dispatch) =>
-      new EditorView(el, {
-        state,
-        editable: () => props.getCapabilities().editArticle,
-        scrollMargin: {
-          top: 100,
-          bottom: 100,
-          left: 0,
-          right: 0,
-        },
-        dispatchTransaction: dispatch,
-        nodeViews: views(props, dispatch),
-        attributes: props.attributes,
-        transformPasted,
-      }),
-}
+export const createEditorView = (
+  props: EditorProps,
+  root: HTMLElement,
+  state: EditorState,
+  dispatch: Dispatch
+) =>
+  new EditorView(root, {
+    state,
+    editable: () => props.getCapabilities().editArticle,
+    scrollMargin: {
+      top: 100,
+      bottom: 100,
+      left: 0,
+      right: 0,
+    },
+    dispatchTransaction: dispatch,
+    nodeViews: views(props, dispatch),
+    attributes: props.attributes,
+    transformPasted,
+  })

--- a/src/index.ts
+++ b/src/index.ts
@@ -25,7 +25,7 @@ export {
   ManuscriptToolbar,
   ToolbarButtonConfig,
 } from './components/toolbar/ManuscriptToolbar'
-export { default as getMenus } from './menus'
+export * from './menus'
 export { ChangeReceiver } from './types'
 export { CollabProvider } from './classes/collabProvider'
 export { PopperManager } from './lib/popper'
@@ -38,5 +38,4 @@ export {
 } from './plugins/comment_annotation'
 export * from './plugins/keywords'
 export * from './lib/utils'
-export { default as useEditor } from './useEditor'
-export { default as ManuscriptsEditor } from './configs//ManuscriptsEditor'
+export * from './useEditor'

--- a/src/menus.tsx
+++ b/src/menus.tsx
@@ -55,9 +55,9 @@ import {
   deleteClosestParentElement,
   findClosestParentElementNodeName,
 } from './lib/hierarchy'
-import useEditor from './useEditor'
+import { useEditor } from './useEditor'
 
-export default (
+export const getMenus = (
   editor: ReturnType<typeof useEditor>,
   handleOpenDialog: (dialog: DialogNames) => void,
   footnotesEnabled?: boolean,

--- a/src/useEditor.ts
+++ b/src/useEditor.ts
@@ -122,6 +122,8 @@ export const useEditor = (props: EditorProps) => {
         200,
         !tr.isGeneric
       )
+
+      return nextState
     },
     [] // eslint-disable-line react-hooks/exhaustive-deps
   )
@@ -205,13 +207,11 @@ export const useEditor = (props: EditorProps) => {
   }, [history, focusNodeWithId])
 
   return {
-    // ordinary use:
     state,
     onRender,
     isCommandValid,
     doCommand,
     replaceState,
-    // advanced use:
     view: view.current,
     dispatch,
   }

--- a/src/useEditor.ts
+++ b/src/useEditor.ts
@@ -33,26 +33,20 @@ import { EditorView } from 'prosemirror-view'
 import { useCallback, useEffect, useRef, useState } from 'react'
 import { useHistory } from 'react-router-dom'
 
-import { EditorProps } from './configs/ManuscriptsEditor'
+import {
+  createEditorState,
+  createEditorView,
+  EditorProps,
+} from './configs/ManuscriptsEditor'
 import { useDoWithDebounce } from './lib/use-do-with-debounce'
-import { bibliographyKey } from './plugins/bibliography'
 
-export type CreateView = (
-  element: HTMLDivElement,
-  state: EditorState,
-  dispatch: (tr: Transaction) => EditorState
-) => EditorView
-
-const useEditor = (
-  initialState: EditorState,
-  createView: CreateView,
-  editorProps: EditorProps
-) => {
+export const useEditor = (props: EditorProps) => {
   const view = useRef<EditorView>()
-  const [state, setState] = useState<EditorState>(initialState)
-  const [viewElement, setViewElement] = useState<HTMLDivElement | null>(null)
+  const [state, setState] = useState<EditorState>(() =>
+    createEditorState(props)
+  )
   const history = useHistory()
-  const { collabProvider } = editorProps
+  const { collabProvider } = props
 
   // Receiving steps from backend
   if (collabProvider) {
@@ -128,33 +122,21 @@ const useEditor = (
         200,
         !tr.isGeneric
       )
-
-      // need to communicate updates of the body-editor the article-editor
-
-      return state
     },
     [] // eslint-disable-line react-hooks/exhaustive-deps
   )
 
-  const replaceView = (state: EditorState, createView: CreateView) => {
-    if (viewElement && view.current) {
-      view.current.destroy()
-      view.current = createView(viewElement, state, dispatch)
-      setState(view.current.state)
-    }
-  }
   const onRender = useCallback((el: HTMLDivElement | null) => {
     if (!el) {
       return
     }
-    view.current = createView(el, view.current?.state || state, dispatch)
-    setState(view.current.state)
-    setViewElement(el)
-    view.current.dispatch(
-      view.current.state.tr.setMeta(bibliographyKey, {
-        initCitations: true,
-      })
+    view.current = createEditorView(
+      props,
+      el,
+      view.current?.state || state,
+      dispatch
     )
+    setState(view.current.state)
   }, []) // eslint-disable-line react-hooks/exhaustive-deps
 
   const isCommandValid = useCallback(
@@ -230,10 +212,7 @@ const useEditor = (
     doCommand,
     replaceState,
     // advanced use:
-    replaceView,
     view: view.current,
     dispatch,
   }
 }
-
-export default useEditor


### PR DESCRIPTION
The way `useEditor` currently works results the initial value of the `EditorState` being created every time a transaction happens. This results in plugins being created and initialized every time the state is updated; even scroll and click triggers this.

This change makes it such that the state is initialized only at the first time `useEditor` is called. 

One thing I wasn't sure about is the new `collabProvider` logic. Should that be wrapped in some kind of hook, or is it OK for it to run multiple times?