### PR TITLE
Create footnotes section when needed - LEAN-3289

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@manuscripts/body-editor",
   "description": "Prosemirror components for editing and viewing manuscripts",
-  "version": "1.6.14",
+  "version": "1.6.15",
   "repository": "github:Atypon-OpenSource/manuscripts-body-editor",
   "license": "Apache-2.0",
   "main": "dist/cjs",

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@manuscripts/body-editor",
   "description": "Prosemirror components for editing and viewing manuscripts",
-  "version": "1.6.17",
+  "version": "1.6.18",
   "repository": "github:Atypon-OpenSource/manuscripts-body-editor",
   "license": "Apache-2.0",
   "main": "dist/cjs",

--- a/src/commands.ts
+++ b/src/commands.ts
@@ -478,6 +478,7 @@ export const insertInlineFootnote =
         footnotesSection.node,
         schema.nodes.footnotes_element
       )
+      // TODO: Revisit this position calculation as it doesn't sound right to always push the note to the end.
       const pos =
         footnotesSection.pos +
         footnoteElement[0].pos +

--- a/src/commands.ts
+++ b/src/commands.ts
@@ -452,11 +452,14 @@ export const insertInlineFootnote =
     // insert the inline footnote, referencing the footnote in the footnotes element in the footnotes section
     tr.insert(insertedAt, node)
 
-    const elements = findChildrenByType(tr.doc, schema.nodes.footnotes_element)
+    const footnotesSection = findChildrenByType(
+      tr.doc,
+      schema.nodes.footnotes_section
+    )[0]
 
     let selectionPos
 
-    if (!elements.length) {
+    if (!footnotesSection) {
       // create a new footnotes section if needed
       const section = state.schema.nodes.footnotes_section.create({}, [
         state.schema.nodes.section_title.create({}, state.schema.text('Notes')),
@@ -470,8 +473,16 @@ export const insertInlineFootnote =
       // inside footnote inside element inside section
       selectionPos = backmatter.pos + section.nodeSize - 3
     } else {
-      const element = elements[0]
-      const pos = element.pos + element.node.nodeSize - 1
+      // Look for footnote element inside the footnotes section to exclude tables footnote elements
+      const footnoteElement = findChildrenByType(
+        footnotesSection.node,
+        schema.nodes.footnotes_element
+      )
+      const pos =
+        footnotesSection.pos +
+        footnoteElement[0].pos +
+        footnoteElement[0].node.nodeSize -
+        1
       tr.insert(pos, footnote)
       selectionPos = pos + 2
     }

--- a/src/views/citation_editable.ts
+++ b/src/views/citation_editable.ts
@@ -47,7 +47,7 @@ import ReactSubView from './ReactSubView'
 
 const createBibliographySection = (node: ManuscriptNode) =>
   schema.nodes.bibliography_section.createAndFill({}, [
-    schema.nodes.section_title.create({}, schema.text('Bibliography')),
+    schema.nodes.section_title.create({}, schema.text('References')),
     schema.nodes.bibliography_element.create({}, node ? [node] : []),
   ]) as ManuscriptNode
 
@@ -214,19 +214,27 @@ export class CitationEditableView extends CitationView<EditableBlockProps> {
   private insertBibliographyNode(item: BibliographyItem) {
     const { doc, tr } = this.view.state
 
-    const elements = findChildrenByType(
+    const biblioSection = findChildrenByType(
       doc,
       schema.nodes.bibliography_element,
       true
     )
 
+    const backmatter = findChildrenByType(doc, schema.nodes.backmatter, true)
+    const backmatterEnd = backmatter[0]
+      ? backmatter[0].node.nodeSize + backmatter[0].pos
+      : 0
+
     const node = this.decoder.decode(item) as BibliographyItemNode
 
-    if (elements.length) {
-      this.view.dispatch(tr.insert(elements[0].pos + 1, node))
+    if (biblioSection.length) {
+      this.view.dispatch(tr.insert(biblioSection[0].pos + 1, node))
     } else {
       this.view.dispatch(
-        tr.insert(tr.doc.content.size, createBibliographySection(node))
+        tr.insert(
+          backmatterEnd ? backmatterEnd - 1 : tr.doc.content.size,
+          createBibliographySection(node)
+        )
       )
     }
 


### PR DESCRIPTION
**Problem**: When inserting a regular footnote, it is now appended to the first table footnotes.

**Expected**: The footnote should be added to a "Notes " section.

This PR ensures:
- Creation of the `Notes` section when needed.
- Insertion of the regular footnote into that section.