### PR TITLE
LEAN-3266 Persist plugin meaningless steps prevention

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@manuscripts/body-editor",
   "description": "Prosemirror components for editing and viewing manuscripts",
-  "version": "1.7.2",
+  "version": "1.7.3",
   "repository": "github:Atypon-OpenSource/manuscripts-body-editor",
   "license": "Apache-2.0",
   "main": "dist/cjs",

--- a/src/plugins/persist.ts
+++ b/src/plugins/persist.ts
@@ -38,11 +38,10 @@ export default () => {
         if (
           node.isInline ||
           isManuscriptNode(node) ||
-          isManuscriptNode(parent)
+          isManuscriptNode(parent) ||
+          !node.type.spec.attrs ||
+          !('id' in node.type.spec.attrs)
         ) {
-          return
-        }
-        if (!node.type.spec.attrs || !('id' in node.type.spec.attrs)) {
           return
         }
         let id = node.attrs.id

--- a/src/plugins/persist.ts
+++ b/src/plugins/persist.ts
@@ -42,6 +42,9 @@ export default () => {
         ) {
           return
         }
+        if (!node.type.spec.attrs || !('id' in node.type.spec.attrs)) {
+          return
+        }
         let id = node.attrs.id
         if (!id || ids.has(id)) {
           id = generateNodeID(node.type)


### PR DESCRIPTION
Due to recent changes in the persist plugin that made it handle duplicated ids created by track changes plugin it started to attempt to add ids to some nodes that don't have ids in their schema which caused hunderds of steps being send to backend with each transaction because their were never applied as invalid and presist plugin attempted again and again.