### PR TITLE
LEAN-3445

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@manuscripts/body-editor",
   "description": "Prosemirror components for editing and viewing manuscripts",
-  "version": "1.7.16",
+  "version": "1.7.17",
   "repository": "github:Atypon-OpenSource/manuscripts-body-editor",
   "license": "Apache-2.0",
   "main": "dist/cjs",

--- a/src/plugins/affiliations.ts
+++ b/src/plugins/affiliations.ts
@@ -25,7 +25,6 @@ import {
   isContributorNode,
   ManuscriptNode,
 } from '@manuscripts/transform'
-import { Node as ProsemirrorNode } from 'prosemirror-model'
 import { Plugin, PluginKey } from 'prosemirror-state'
 import { Decoration, DecorationSet } from 'prosemirror-view'
 
@@ -36,6 +35,7 @@ import {
 } from '../lib/track-changes-utils'
 
 interface PluginState {
+  id: string
   indexedAffiliationIds: Map<string, number> // key is authore id
   contributors: Array<[ContributorNode, number]>
   affiliations: Array<[AffiliationNode, number]>
@@ -43,6 +43,7 @@ interface PluginState {
 
 export const affiliationsKey = new PluginKey<PluginState>('affiliations')
 
+let id = 1
 export const buildPluginState = (doc: ManuscriptNode): PluginState => {
   const contributors: Array<[ContributorNode, number]> = []
   const affiliations: Array<[AffiliationNode, number]> = []
@@ -78,13 +79,12 @@ export const buildPluginState = (doc: ManuscriptNode): PluginState => {
   )
 
   return {
+    id: String(id++),
     indexedAffiliationIds,
     contributors,
     affiliations,
   }
 }
-
-let count = 0
 
 export default () => {
   return new Plugin<PluginState>({
@@ -142,28 +142,15 @@ export default () => {
     props: {
       decorations: (state) => {
         const decorations: Decoration[] = []
-        const allNodes: Array<[ProsemirrorNode, number]> = []
-
-        state.doc.descendants((node, pos) => {
-          if (isAffiliationNode(node) || isContributorNode(node)) {
-            allNodes.push([node, pos])
-          }
+        const aff = affiliationsKey.getState(state) as PluginState
+        const nodes = [...aff.contributors, ...aff.affiliations]
+        nodes.forEach(([node, pos]) => {
+          decorations.push(
+            Decoration.node(pos, pos + node.nodeSize, {
+              refresh: aff.id,
+            })
+          )
         })
-
-        if (allNodes.length) {
-          allNodes.forEach(([node, pos]) => {
-            decorations.push(
-              Decoration.node(
-                pos,
-                pos + node.nodeSize,
-                {},
-                {
-                  refresh: count++,
-                }
-              )
-            )
-          })
-        }
 
         return DecorationSet.create(state.doc, decorations)
       },

--- a/src/plugins/affiliations.ts
+++ b/src/plugins/affiliations.ts
@@ -35,7 +35,7 @@ import {
 } from '../lib/track-changes-utils'
 
 interface PluginState {
-  id: string
+  version: string
   indexedAffiliationIds: Map<string, number> // key is authore id
   contributors: Array<[ContributorNode, number]>
   affiliations: Array<[AffiliationNode, number]>
@@ -79,7 +79,7 @@ export const buildPluginState = (doc: ManuscriptNode): PluginState => {
   )
 
   return {
-    id: String(id++),
+    version: String(id++),
     indexedAffiliationIds,
     contributors,
     affiliations,
@@ -147,7 +147,7 @@ export default () => {
         nodes.forEach(([node, pos]) => {
           decorations.push(
             Decoration.node(pos, pos + node.nodeSize, {
-              refresh: aff.id,
+              version: aff.version,
             })
           )
         })

--- a/src/plugins/bibliography/bibliography-utils.ts
+++ b/src/plugins/bibliography/bibliography-utils.ts
@@ -70,7 +70,7 @@ export const buildDecorations = (state: PluginState, doc: ManuscriptNode) => {
     }
     decorations.push(
       Decoration.node(pos, pos + node.nodeSize, {
-        id: state.id,
+        version: state.version,
       })
     )
   }
@@ -106,7 +106,7 @@ export const buildDecorations = (state: PluginState, doc: ManuscriptNode) => {
     if (isBibliographyElement(node)) {
       decorations.push(
         Decoration.node(pos, pos + node.nodeSize, {
-          id: state.id,
+          version: state.version,
         })
       )
     }

--- a/src/plugins/bibliography/bibliography-utils.ts
+++ b/src/plugins/bibliography/bibliography-utils.ts
@@ -42,8 +42,6 @@ export const isBibliographyElement = (node: ManuscriptNode) =>
 
 export type CitationNodes = [CitationNode, number][]
 
-let count = 0
-
 export const buildDecorations = (state: PluginState, doc: ManuscriptNode) => {
   const decorations: Decoration[] = []
 
@@ -72,7 +70,7 @@ export const buildDecorations = (state: PluginState, doc: ManuscriptNode) => {
     }
     decorations.push(
       Decoration.node(pos, pos + node.nodeSize, {
-        'data-updated': Date.now().toString(),
+        id: state.id,
       })
     )
   }
@@ -81,14 +79,9 @@ export const buildDecorations = (state: PluginState, doc: ManuscriptNode) => {
     doc.descendants((node, pos) => {
       if (isBibliographyElement(node)) {
         decorations.push(
-          Decoration.node(
-            pos,
-            pos + node.nodeSize,
-            {},
-            {
-              missing: true,
-            }
-          )
+          Decoration.node(pos, pos + node.nodeSize, {
+            missing: 'true',
+          })
         )
 
         decorations.push(
@@ -112,14 +105,9 @@ export const buildDecorations = (state: PluginState, doc: ManuscriptNode) => {
   doc.descendants((node, pos) => {
     if (isBibliographyElement(node)) {
       decorations.push(
-        Decoration.node(
-          pos,
-          pos + node.nodeSize,
-          {},
-          {
-            refresh: count++,
-          }
-        )
+        Decoration.node(pos, pos + node.nodeSize, {
+          id: state.id,
+        })
       )
     }
   })

--- a/src/plugins/bibliography/index.ts
+++ b/src/plugins/bibliography/index.ts
@@ -35,7 +35,7 @@ import {
 export const bibliographyKey = new PluginKey<PluginState>('bibliography')
 
 export interface PluginState {
-  id: string
+  version: string
   citationNodes: CitationNodes
   citations: CiteProc.Citation[]
   bibliographyItems: Map<string, BibliographyItem>
@@ -76,7 +76,7 @@ export default (props: BibliographyProps) => {
   })
 }
 
-let id = 1
+let version = 1
 const buildBibliographyPluginState = (
   doc: ManuscriptNode,
   csl: CSLProps,
@@ -109,7 +109,7 @@ const buildBibliographyPluginState = (
     isEqual(citations, $old.citations) &&
     isEqual(bibliographyItemMap, $old.bibliographyItems)
   ) {
-    $new.id = $old.id
+    $new.version = $old.version
     $new.citationCounts = $old.citationCounts
     $new.provider = $old.provider
     $new.renderedCitations = $old.renderedCitations
@@ -130,7 +130,7 @@ const buildBibliographyPluginState = (
     //create new citations since CitationProvider modifies the ones passed
     const citationTexts = provider.rebuildState(buildCitations(nodes))
 
-    $new.id = String(id++)
+    $new.version = String(version++)
     $new.citationCounts = citationCounts
     $new.provider = provider
     $new.renderedCitations = new Map(citationTexts.map((i) => [i[0], i[2]]))

--- a/src/plugins/bibliography/index.ts
+++ b/src/plugins/bibliography/index.ts
@@ -35,6 +35,7 @@ import {
 export const bibliographyKey = new PluginKey<PluginState>('bibliography')
 
 export interface PluginState {
+  id: string
   citationNodes: CitationNodes
   citations: CiteProc.Citation[]
   bibliographyItems: Map<string, BibliographyItem>
@@ -75,6 +76,7 @@ export default (props: BibliographyProps) => {
   })
 }
 
+let id = 1
 const buildBibliographyPluginState = (
   doc: ManuscriptNode,
   csl: CSLProps,
@@ -107,6 +109,7 @@ const buildBibliographyPluginState = (
     isEqual(citations, $old.citations) &&
     isEqual(bibliographyItemMap, $old.bibliographyItems)
   ) {
+    $new.id = $old.id
     $new.citationCounts = $old.citationCounts
     $new.provider = $old.provider
     $new.renderedCitations = $old.renderedCitations
@@ -127,6 +130,7 @@ const buildBibliographyPluginState = (
     //create new citations since CitationProvider modifies the ones passed
     const citationTexts = provider.rebuildState(buildCitations(nodes))
 
+    $new.id = String(id++)
     $new.citationCounts = citationCounts
     $new.provider = provider
     $new.renderedCitations = new Map(citationTexts.map((i) => [i[0], i[2]]))

--- a/src/plugins/selected-suggestion-ui.ts
+++ b/src/plugins/selected-suggestion-ui.ts
@@ -132,10 +132,7 @@ export default (props: SelectedSuggestionProps) =>
           return buildSelectedSuggestionDecoration(suggestionId, state, props)
         }
 
-        if (
-          tr.getMeta(CLEAR_SUGGESTION_ID) ||
-          tr.getMeta('track-changes-refresh-changes')
-        ) {
+        if (tr.getMeta(CLEAR_SUGGESTION_ID)) {
           props.setEditorSelectedSuggestion(undefined)
           return DecorationSet.empty
         }


### PR DESCRIPTION
Instead of generating a new number every time, I updated the bib/aff plugins to save the version as part of the state, and use it when building the decorations. This prevents the editor from redrawing the nodes.