### PR TITLE
LEAN-3513 Fix: "Out of range" In Table footnotes

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@manuscripts/body-editor",
   "description": "Prosemirror components for editing and viewing manuscripts",
-  "version": "1.7.29",
+  "version": "1.7.30",
   "repository": "github:Atypon-OpenSource/manuscripts-body-editor",
   "license": "Apache-2.0",
   "main": "dist/cjs",

--- a/src/plugins/table-footnote.ts
+++ b/src/plugins/table-footnote.ts
@@ -43,10 +43,10 @@ export default () => {
   return new Plugin({
     appendTransaction(transactions, oldState, newState) {
       const tableInlineFootnoteChange = transactions.find((tr) =>
-        tr.steps.find((s) => {
+        tr.steps.find((s, i) => {
           if (s instanceof ReplaceStep) {
             const step = s as ReplaceStep
-            const $pos = oldState.doc.resolve(step.from)
+            const $pos = tr.docs[i].resolve(step.from)
 
             return (
               $pos.node($pos.depth - 2)?.type === schema.nodes.table &&


### PR DESCRIPTION
Table footnotes plugins generate this error on empty document while attempting to add graphical abstract. The plugin tries a position resolution on an incorrect document.