### PR TITLE
LEAN-3638: LW-FY25-Q1-S1: Insert Reference Note Option Incorrectly En…

### DIFF
--- a/src/lib/context-menu.ts
+++ b/src/lib/context-menu.ts
@@ -278,7 +278,7 @@ export class ContextMenu {
 
     if (type === schema.nodes.table_element) {
       // Check if the selection is inside the table.
-      const isInTable = hasParentNodeOfType(schema.nodes.table)(
+      const isInTableCell = hasParentNodeOfType(schema.nodes.table_cell)(
         this.view.state.selection
       )
       const tableElementFooter = findChildrenByType(
@@ -319,7 +319,7 @@ export class ContextMenu {
         )
       }
 
-      if (isInTable) {
+      if (isInTableCell) {
         menu.appendChild(
           this.createMenuSection((section: HTMLElement) => {
             section.appendChild(


### PR DESCRIPTION
When selecting a table cell and then clicking on the context menu to add a reference note, the "Add Reference Note" option is mistakenly enabled for all other tables because of an incorrect selection check. I am now implementing a check based on the selection of the table cell instead.