### PR TITLE
LEAN-3970: Deleting the Last Footnote Removes Footnote Element and Di…

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@manuscripts/body-editor",
   "description": "Prosemirror components for editing and viewing manuscripts",
-  "version": "2.2.0",
+  "version": "2.2.1",
   "repository": "github:Atypon-OpenSource/manuscripts-body-editor",
   "license": "Apache-2.0",
   "main": "dist/cjs",

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@manuscripts/body-editor",
   "description": "Prosemirror components for editing and viewing manuscripts",
-  "version": "2.0.57",
+  "version": "2.0.58-LEAN-3970-v0.0",
   "repository": "github:Atypon-OpenSource/manuscripts-body-editor",
   "license": "Apache-2.0",
   "main": "dist/cjs",

--- a/src/plugins/footnotes/widgets.ts
+++ b/src/plugins/footnotes/widgets.ts
@@ -103,7 +103,7 @@ export const deleteFootnoteWidget =
           ) {
             const { pos: fnPos, node: fnNode } = tableElementFooter
             tr.delete(fnPos, fnPos + fnNode.nodeSize + 1)
-          } else if (footnotesElement?.node.childCount === 1 && tableElement) { // remove footnotesElement only for table footnotes 
+          } else if (footnotesElement?.node.childCount === 1) {
             const { pos: fnPos, node: fnNode } = footnotesElement
             tr.delete(fnPos, fnPos + fnNode.nodeSize + 1)
           } else {

--- a/src/plugins/footnotes/widgets.ts
+++ b/src/plugins/footnotes/widgets.ts
@@ -103,7 +103,7 @@ export const deleteFootnoteWidget =
           ) {
             const { pos: fnPos, node: fnNode } = tableElementFooter
             tr.delete(fnPos, fnPos + fnNode.nodeSize + 1)
-          } else if (footnotesElement?.node.childCount === 1) {
+          } else if (footnotesElement?.node.childCount === 1 && tableElement) { // remove footnotesElement only for table footnotes 
             const { pos: fnPos, node: fnNode } = footnotesElement
             tr.delete(fnPos, fnPos + fnNode.nodeSize + 1)
           } else {


### PR DESCRIPTION
This issue was a regression that occurred after fixing LEAN-3741, which was specifically reported for table footnotes, not regular footnotes. I resolved the issue by removing the footnotes element only for table footnotes. I found that removing the footnotes element for regular footnotes is unnecessary and doesn't make sense. There's no reason to remove the footnotes element while still keeping the footnotes section. The footnotes section node only contains the footnote heading and the footnotes element, so removing the element while leaving the heading and section in place is illogical. It misleads users into thinking they can still add footnotes, even though the wrapper for footnotes has been removed. The footnotes element should only be removed when the entire section is deleted.
Taking into account that the current process of removing the footnotes element when there's only one child is not accurate, it doesn't consistently remove the footnotes element when deleting all footnotes at once, especially if multiple footnotes are removed simultaneously. Currently, the element is only removed when there's a single child left, which needs improvement to ensure the footnotes element is properly removed when all footnotes are deleted, regardless of how many were removed at the same time.