### PR TITLE
LEAN-4161: LW-FY25-Q3-S2: Unable to Delete the GA Section

### DIFF
--- a/src/plugins/sections.ts
+++ b/src/plugins/sections.ts
@@ -70,6 +70,18 @@ const preventTitleEdit = (tr: Transaction) => {
            and preventing that change
            */
           if (isGraphicalAbstractSectionNode(node) || isKeywordsNode(node)) {
+            const nodeRangeStart = nodePos
+            const nodeRangeEnd = nodePos + node.nodeSize
+
+            // Detect if the change is a deletion (complete removal of the node)
+            const isDeletion = fromA <= nodeRangeStart && toA >= nodeRangeEnd
+
+            if (isDeletion) {
+              // Allow deletion of the node
+              return true
+            }
+
+            // Prevent updates to the section title in graphical abstract or keywords
             node.descendants((childNode, childPos) => {
               const inDocPos = nodePos + childPos
 
@@ -83,7 +95,6 @@ const preventTitleEdit = (tr: Transaction) => {
               }
             })
           }
-          // check if one is graphical abstract and another one is a title
         })
       })
     })

--- a/src/plugins/sections.ts
+++ b/src/plugins/sections.ts
@@ -72,7 +72,6 @@ const preventTitleEdit = (tr: Transaction) => {
           if (isGraphicalAbstractSectionNode(node) || isKeywordsNode(node)) {
             const nodeRangeStart = nodePos
             const nodeRangeEnd = nodePos + node.nodeSize
-
             // Detect if the change is a deletion (complete removal of the node)
             const isDeletion = fromA <= nodeRangeStart && toA >= nodeRangeEnd
 

--- a/src/plugins/sections.ts
+++ b/src/plugins/sections.ts
@@ -94,6 +94,7 @@ const preventTitleEdit = (tr: Transaction) => {
               }
             })
           }
+          // check if one is graphical abstract and another one is a title
         })
       })
     })


### PR DESCRIPTION
Resolve the issue of being unable to delete a graphical abstract node while maintaining the functionality of detecting changes in the `graphicalAbstractSection` and `keywords` nodes by differentiating between update and deletion functionalities 