### PR TITLE
LEAN-4199

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@manuscripts/body-editor",
   "description": "Prosemirror components for editing and viewing manuscripts",
-  "version": "2.6.34",
+  "version": "2.6.35-LEAN-4199.0",
   "repository": "github:Atypon-OpenSource/manuscripts-body-editor",
   "license": "Apache-2.0",
   "main": "dist/cjs",
@@ -32,7 +32,7 @@
     "@iarna/word-count": "^1.1.2",
     "@manuscripts/json-schema": "2.2.11",
     "@manuscripts/library": "1.3.11",
-    "@manuscripts/style-guide": "2.0.26",
+    "@manuscripts/style-guide": "2.0.27-LEAN-4199.0",
     "@manuscripts/track-changes-plugin": "1.8.5",
     "@manuscripts/transform": "3.0.26",
     "@popperjs/core": "^2.11.8",

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@manuscripts/body-editor",
   "description": "Prosemirror components for editing and viewing manuscripts",
-  "version": "2.6.35-LEAN-4199.0",
+  "version": "2.6.35",
   "repository": "github:Atypon-OpenSource/manuscripts-body-editor",
   "license": "Apache-2.0",
   "main": "dist/cjs",
@@ -32,7 +32,7 @@
     "@iarna/word-count": "^1.1.2",
     "@manuscripts/json-schema": "2.2.11",
     "@manuscripts/library": "1.3.11",
-    "@manuscripts/style-guide": "2.0.27-LEAN-4199.0",
+    "@manuscripts/style-guide": "2.0.27",
     "@manuscripts/track-changes-plugin": "1.8.5",
     "@manuscripts/transform": "3.0.26",
     "@popperjs/core": "^2.11.8",

--- a/src/components/toolbar/ListMenuItem.tsx
+++ b/src/components/toolbar/ListMenuItem.tsx
@@ -55,7 +55,11 @@ export const ListStyles: React.FC<ListSubmenuItemsProps> = ({
   return (
     <ListContainer>
       {styles.map((style, index) => (
-        <StyleBlock key={index} onClick={() => onClick(style, index)}>
+        <StyleBlock
+          data-cy="submenu"
+          key={index}
+          onClick={() => onClick(style, index)}
+        >
           {styleItems[style].map((item, index) => (
             <BlockItem key={index}>
               <Label hide={item === '-'}>{item}</Label>

--- a/src/lib/track-changes-utils.ts
+++ b/src/lib/track-changes-utils.ts
@@ -15,9 +15,12 @@
  */
 
 import { EditAttrsTrackingIcon } from '@manuscripts/style-guide'
-import { TrackedAttrs } from '@manuscripts/track-changes-plugin'
+import {
+  CHANGE_OPERATION,
+  TrackedAttrs,
+} from '@manuscripts/track-changes-plugin'
 import { schema } from '@manuscripts/transform'
-import { Fragment, Node as ProsemirrorNode } from 'prosemirror-model'
+import { Attrs, Fragment, Node as ProsemirrorNode } from 'prosemirror-model'
 import { createElement } from 'react'
 import { renderToStaticMarkup } from 'react-dom/server'
 
@@ -147,4 +150,35 @@ export function sanitizeAttrsChange<T extends ProsemirrorNode>(
     acc[key] = newAttr[key]
     return acc
   }, {} as T['attrs'])
+}
+
+const classNames = new Map([
+  [CHANGE_OPERATION.insert, 'inserted'],
+  [CHANGE_OPERATION.delete, 'deleted'],
+  [CHANGE_OPERATION.set_node_attributes, 'set_attrs'],
+])
+export const addTrackChangesAttributes = (attrs: Attrs, dom: Element) => {
+  dom.removeAttribute('data-track-id')
+  dom.removeAttribute('data-track-op')
+  dom.removeAttribute('data-track-status')
+
+  const changes = attrs.dataTracked as TrackedAttrs[]
+  if (!changes || !changes.length) {
+    return
+  }
+  const change = changes[0]
+  dom.setAttribute('data-track-id', change.id)
+  dom.setAttribute('data-track-op', change.operation)
+  dom.setAttribute('data-track-status', change.status)
+}
+
+export const addTrackChangesClassNames = (attrs: Attrs, dom: Element) => {
+  dom.classList.remove(...classNames.values())
+
+  const changes = attrs.dataTracked as TrackedAttrs[]
+  if (!changes || !changes.length) {
+    return
+  }
+  const change = changes[0]
+  dom.classList.add(classNames.get(change.operation) || '')
 }

--- a/src/views/affiliations.ts
+++ b/src/views/affiliations.ts
@@ -18,6 +18,7 @@ import { AffiliationNode } from '@manuscripts/transform'
 import { NodeSelection } from 'prosemirror-state'
 
 import { AffiliationAttrs, affiliationName } from '../lib/authors'
+import { addTrackChangesAttributes } from '../lib/track-changes-utils'
 import { findChildByID } from '../lib/view'
 import { affiliationsKey, PluginState } from '../plugins/affiliations'
 import { selectedSuggestionKey } from '../plugins/selected-suggestion'
@@ -25,6 +26,7 @@ import { Trackable } from '../types'
 import BlockView from './block_view'
 import { createNodeView } from './creators'
 
+//todo update AffiliationNode to AffiliationsNode
 export class AffiliationsView extends BlockView<Trackable<AffiliationNode>> {
   version: string
   container: HTMLElement
@@ -32,7 +34,7 @@ export class AffiliationsView extends BlockView<Trackable<AffiliationNode>> {
   public ignoreMutation = () => true
   public stopEvent = () => true
 
-  public createElement = () => {
+  public createElement() {
     this.container = document.createElement('div')
     this.container.classList.add('affiliations', 'block')
     this.container.contentEditable = 'false'
@@ -41,7 +43,7 @@ export class AffiliationsView extends BlockView<Trackable<AffiliationNode>> {
     this.dom.appendChild(this.container)
   }
 
-  public updateContents = () => {
+  public updateContents() {
     const affs = affiliationsKey.getState(this.view.state)
     if (!affs) {
       return
@@ -56,7 +58,7 @@ export class AffiliationsView extends BlockView<Trackable<AffiliationNode>> {
     this.updateSelection()
   }
 
-  private buildAffiliations = (affs: PluginState) => {
+  private buildAffiliations(affs: PluginState) {
     const elements = []
     for (const affiliation of affs.affiliations) {
       const index = affs.indexedAffiliationIds.get(affiliation.id)
@@ -71,16 +73,11 @@ export class AffiliationsView extends BlockView<Trackable<AffiliationNode>> {
       .forEach((e) => this.container.appendChild(e.element))
   }
 
-  private buildAffiliation = (attrs: AffiliationAttrs, index?: number) => {
+  private buildAffiliation(attrs: AffiliationAttrs, index?: number) {
     const element = document.createElement('div')
     element.classList.add('affiliation')
     element.id = attrs.id
-    if (attrs.dataTracked?.length) {
-      const change = attrs.dataTracked[0]
-      element.setAttribute('data-track-id', change.id)
-      element.setAttribute('data-track-status', change.status)
-      element.setAttribute('data-track-op', change.operation)
-    }
+    addTrackChangesAttributes(attrs, element)
 
     if (index) {
       const label = document.createElement('span')
@@ -96,13 +93,13 @@ export class AffiliationsView extends BlockView<Trackable<AffiliationNode>> {
     return element
   }
 
-  sortAffiliations = (aff1: { index?: number }, aff2: { index?: number }) => {
+  private sortAffiliations(aff1: { index?: number }, aff2: { index?: number }) {
     const index1 = aff1.index || 10000
     const index2 = aff2.index || 10000
     return index1 - index2
   }
 
-  private handleClick = (event: Event) => {
+  private handleClick(event: Event) {
     const element = event.target as HTMLElement
     const item = element.closest('.affiliation')
 
@@ -118,7 +115,7 @@ export class AffiliationsView extends BlockView<Trackable<AffiliationNode>> {
     }
   }
 
-  private updateSelection = () => {
+  private updateSelection() {
     const state = this.view.state
     const selection = selectedSuggestionKey.getState(state)?.suggestion
     this.container

--- a/src/views/author_notes.ts
+++ b/src/views/author_notes.ts
@@ -37,7 +37,8 @@ export class AuthorNotesView extends BlockView<Trackable<AuthorNotesNode>> {
     this.dom.appendChild(this.container)
   }
 
-  public updateContents = () => {
+  public updateContents() {
+    super.updateContents()
     this.genericHeaderIsDisplayed = false
     this.dom.setAttribute('contenteditable', 'false')
     this.container.innerHTML = ''

--- a/src/views/award.ts
+++ b/src/views/award.ts
@@ -21,13 +21,13 @@ import BlockView from './block_view'
 import { createNodeView } from './creators'
 
 export class AwardView extends BlockView<Trackable<AwardNode>> {
-  public initialise = () => {
+  public initialise() {
     this.createDOM()
     this.contentDOM = this.dom
     this.updateContents()
   }
 
-  public updateContents = () => {
+  public updateContents() {
     if (!this.contentDOM) {
       return
     }

--- a/src/views/awards.ts
+++ b/src/views/awards.ts
@@ -34,7 +34,8 @@ export class AwardsView extends BlockView<AwardsNode> {
     this.dom.appendChild(this.wrapper)
   }
 
-  public updateContents = () => {
+  public updateContents() {
+    super.updateContents()
     if (!this.contentDOM) {
       return
     }

--- a/src/views/base_node_view.ts
+++ b/src/views/base_node_view.ts
@@ -58,6 +58,9 @@ export class BaseNodeView<Node extends ManuscriptNode> implements NodeView {
     if (this.node.attrs.id) {
       this.dom.id = this.node.attrs.id
     }
+    if (this.contentDOM) {
+      this.contentDOM.removeAttribute('id')
+    }
     this.handleTrackChanges()
     // extend this
   }

--- a/src/views/bibliography_element.ts
+++ b/src/views/bibliography_element.ts
@@ -30,6 +30,7 @@ import {
 import { CommentKey, createCommentMarker } from '../lib/comments'
 import { sanitize } from '../lib/dompurify'
 import { BibliographyItemAttrs } from '../lib/references'
+import { addTrackChangesAttributes } from '../lib/track-changes-utils'
 import { deleteNode, findChildByID, updateNodeAttrs } from '../lib/view'
 import { getBibliographyPluginState } from '../plugins/bibliography'
 import { commentsKey, setCommentSelection } from '../plugins/comments'
@@ -38,7 +39,6 @@ import { Trackable } from '../types'
 import BlockView from './block_view'
 import { createNodeView } from './creators'
 import ReactSubView from './ReactSubView'
-import {addTrackChangesAttributes} from "../lib/track-changes-utils";
 
 export class BibliographyElementBlockView extends BlockView<
   Trackable<BibliographyElementNode>
@@ -90,7 +90,7 @@ export class BibliographyElementBlockView extends BlockView<
     }
   }
 
-  private showContextMenu(element: HTMLElement){
+  private showContextMenu(element: HTMLElement) {
     this.props.popper.destroy()
     const can = this.props.getCapabilities()
     const componentProps: ContextMenuProps = {
@@ -121,7 +121,7 @@ export class BibliographyElementBlockView extends BlockView<
     this.props.popper.show(element, this.contextMenu, 'right-start')
   }
 
-  private handleClick(event: Event) {
+  private handleClick = (event: Event) => {
     const element = event.target as HTMLElement
     // Handle click on comment marker
     const marker = element.closest('.comment-marker') as HTMLElement

--- a/src/views/bibliography_element.ts
+++ b/src/views/bibliography_element.ts
@@ -30,7 +30,6 @@ import {
 import { CommentKey, createCommentMarker } from '../lib/comments'
 import { sanitize } from '../lib/dompurify'
 import { BibliographyItemAttrs } from '../lib/references'
-import { getChangeClasses } from '../lib/track-changes-utils'
 import { deleteNode, findChildByID, updateNodeAttrs } from '../lib/view'
 import { getBibliographyPluginState } from '../plugins/bibliography'
 import { commentsKey, setCommentSelection } from '../plugins/comments'
@@ -39,6 +38,7 @@ import { Trackable } from '../types'
 import BlockView from './block_view'
 import { createNodeView } from './creators'
 import ReactSubView from './ReactSubView'
+import {addTrackChangesAttributes} from "../lib/track-changes-utils";
 
 export class BibliographyElementBlockView extends BlockView<
   Trackable<BibliographyElementNode>
@@ -48,7 +48,7 @@ export class BibliographyElementBlockView extends BlockView<
   private contextMenu: HTMLDivElement
   private version: string
 
-  public showPopper = (id: string) => {
+  public showPopper(id: string) {
     const bib = getBibliographyPluginState(this.view.state)
     if (!bib) {
       return
@@ -79,18 +79,18 @@ export class BibliographyElementBlockView extends BlockView<
 
   public ignoreMutation = () => true
 
-  private handleEdit = (citationId: string) => {
-    this.showPopper(citationId)
+  private handleEdit(citationID: string) {
+    this.showPopper(citationID)
   }
 
-  private handleComment = (itemID: string) => {
+  private handleComment(itemID: string) {
     const item = findChildByID(this.view, itemID)
     if (item) {
       addNodeComment(item.node, this.view.state, this.props.dispatch)
     }
   }
 
-  private showContextMenu = (element: HTMLElement) => {
+  private showContextMenu(element: HTMLElement){
     this.props.popper.destroy()
     const can = this.props.getCapabilities()
     const componentProps: ContextMenuProps = {
@@ -121,7 +121,7 @@ export class BibliographyElementBlockView extends BlockView<
     this.props.popper.show(element, this.contextMenu, 'right-start')
   }
 
-  private handleClick = (event: Event) => {
+  private handleClick(event: Event) {
     const element = event.target as HTMLElement
     // Handle click on comment marker
     const marker = element.closest('.comment-marker') as HTMLElement
@@ -149,7 +149,7 @@ export class BibliographyElementBlockView extends BlockView<
     }
   }
 
-  public updateContents = () => {
+  public updateContents() {
     this.props.popper.destroy() // destroy the old context menu
     const bib = getBibliographyPluginState(this.view.state)
     if (!bib) {
@@ -186,14 +186,7 @@ export class BibliographyElementBlockView extends BlockView<
       const comment = createCommentMarker('div', id)
       element.prepend(comment)
 
-      node.attrs as BibliographyItemAttrs
-
-      const attrs = node.attrs as BibliographyItemAttrs
-      const change = attrs.dataTracked?.[0]
-      if (change) {
-        element.classList.add(...getChangeClasses([change]))
-        element.dataset.trackId = change.id
-      }
+      addTrackChangesAttributes(node.attrs, element)
 
       wrapper.append(element)
     }

--- a/src/views/block_view.ts
+++ b/src/views/block_view.ts
@@ -14,30 +14,16 @@
  * limitations under the License.
  */
 
-import { TrackedAttrs } from '@manuscripts/track-changes-plugin'
-import {
-  ManuscriptNode,
-  ManuscriptNodeView,
-  schema,
-} from '@manuscripts/transform'
-import { ResolvedPos } from 'prosemirror-model'
+import { ManuscriptNode, ManuscriptNodeView } from '@manuscripts/transform'
 
+import { addTrackChangesAttributes } from '../lib/track-changes-utils'
 import { BaseNodeView } from './base_node_view'
-
-const isGraphicalAbstractFigure = ($pos: ResolvedPos, doc: ManuscriptNode) =>
-  $pos.parent.type === schema.nodes.graphical_abstract_section &&
-  doc.nodeAt($pos.pos)?.type === schema.nodes.figure_element
 
 export default class BlockView<BlockNode extends ManuscriptNode>
   extends BaseNodeView<BlockNode>
   implements ManuscriptNodeView
 {
-  public viewAttributes = {
-    id: 'id',
-    placeholder: 'placeholder',
-  }
-
-  public initialise = () => {
+  public initialise() {
     this.createDOM()
     this.createGutter('block-gutter', this.gutterButtons().filter(Boolean))
     this.createElement()
@@ -48,84 +34,48 @@ export default class BlockView<BlockNode extends ManuscriptNode>
     this.updateContents()
   }
 
-  public updateContents = () => {
+  public updateContents() {
+    super.updateContents()
     this.updateClasses()
-    this.updateAttributes()
-    this.onUpdateContent()
+    this.updatePlaceholder()
   }
 
-  // unfortunately we can't call updateContents in successors because they are not methods but props
-  // which means they're inited in the constructor and are not accessible via super.
-  // onUpdateContent is provided here to allow to execute additional actions on content update without a need to copy all the code
-  // @TODO - rewrite arrow props to methods
-  onUpdateContent() {
-    return
+  handleTrackChanges() {
+    addTrackChangesAttributes(this.node.attrs, this.dom)
   }
 
-  public updateClasses = () => {
+  public updateClasses() {
     if (!this.contentDOM) {
       return
     }
-
     this.contentDOM.classList.toggle('empty-node', !this.node.childCount)
   }
 
-  public updateAttributes = () => {
+  public updatePlaceholder() {
     if (!this.contentDOM) {
       return
     }
-
-    const dataTracked = (this.node.attrs.dataTracked || []).filter(
-      (attr: TrackedAttrs) => attr.operation !== 'reference'
-    )
-
-    if (dataTracked?.length) {
-      const lastChange = dataTracked[dataTracked.length - 1]
-      this.dom.setAttribute('data-track-status', lastChange.status)
-      this.dom.setAttribute('data-track-op', lastChange.operation)
-    } else {
-      this.dom.removeAttribute('data-track-status')
-      this.dom.removeAttribute('data-track-op')
-    }
-
-    for (const [key, target] of Object.entries(this.viewAttributes)) {
-      if (key in this.node.attrs) {
-        const value = this.node.attrs[key]
-
-        if (value) {
-          this.contentDOM.setAttribute(target, value)
-        } else {
-          this.contentDOM.removeAttribute(target)
-        }
-      }
+    if (this.node.attrs.placeholder) {
+      this.contentDOM.dataset.placeholder = this.node.attrs.placeholder
     }
   }
 
-  public createElement = () => {
+  public createElement() {
     this.contentDOM = document.createElement(this.elementType)
     this.contentDOM.className = 'block'
-
     this.dom.appendChild(this.contentDOM)
   }
 
-  public createDOM = () => {
+  public createDOM() {
     this.dom = document.createElement('div')
     this.dom.classList.add('block-container')
     this.dom.classList.add(`block-${this.node.type.name}`)
   }
 
-  public createGutter = (className: string, buttons: HTMLElement[]) => {
+  public createGutter(className: string, buttons: HTMLElement[]) {
     const gutter = document.createElement('div')
     gutter.setAttribute('contenteditable', 'false')
     gutter.classList.add(className)
-    if (
-      isGraphicalAbstractFigure(
-        this.view.state.doc.resolve(this.getPos()),
-        this.view.state.doc
-      )
-    ) {
-      gutter.classList.add('graphical-abstract-figure')
-    }
 
     for (const button of buttons) {
       gutter.appendChild(button)
@@ -134,7 +84,11 @@ export default class BlockView<BlockNode extends ManuscriptNode>
     this.dom.appendChild(gutter)
   }
 
-  public gutterButtons = (): HTMLElement[] => []
+  public gutterButtons(): HTMLElement[] {
+    return []
+  }
 
-  public actionGutterButtons = (): HTMLElement[] => []
+  public actionGutterButtons(): HTMLElement[] {
+    return []
+  }
 }

--- a/src/views/bullet_list.ts
+++ b/src/views/bullet_list.ts
@@ -16,7 +16,6 @@
 
 import { ListNode, ManuscriptNode } from '@manuscripts/transform'
 
-import { getChangeClasses } from '../lib/track-changes-utils'
 import { Trackable } from '../types'
 import BlockView from './block_view'
 import { createNodeOrElementView } from './creators'
@@ -25,36 +24,16 @@ import { JATS_HTML_LIST_STYLE_MAPPING, JatsStyleType } from './ordered_list'
 export class BulletListView extends BlockView<Trackable<ListNode>> {
   public elementType = 'ul'
 
-  public updateContents = () => {
+  public updateContents() {
+    super.updateContents()
     if (this.contentDOM) {
       const type = (this.node.attrs.listStyleType as JatsStyleType) || 'bullet'
       this.contentDOM.style.listStyleType = JATS_HTML_LIST_STYLE_MAPPING[type]
-
-      const classes = [
-        'block',
-        ...getChangeClasses(this.node.attrs.dataTracked),
-      ]
-
-      if (this.node.attrs.dataTracked) {
-        this.dom.setAttribute(
-          'data-track-status',
-          this.node.attrs.dataTracked[0].status
-        )
-        this.dom.setAttribute(
-          'data-track-op',
-          this.node.attrs.dataTracked[0].operation
-        )
-      } else {
-        this.dom.removeAttribute('data-track-status')
-        this.dom.removeAttribute('data-track-op')
-      }
-      this.contentDOM.className = classes.join(' ')
     }
   }
 }
 
 export const bulletListCallback = (node: ManuscriptNode, dom: HTMLElement) => {
-  dom.classList.add('list')
   const type = (node.attrs.listStyleType as JatsStyleType) || 'bullet'
   dom.style.listStyleType = JATS_HTML_LIST_STYLE_MAPPING[type]
 }

--- a/src/views/citation_editable.ts
+++ b/src/views/citation_editable.ts
@@ -47,6 +47,12 @@ export class CitationEditableView extends CitationView {
   private editor: HTMLElement
   private contextMenu: HTMLElement
   private can = this.props.getCapabilities()
+
+  createDOM() {
+    super.createDOM()
+    this.dom.addEventListener('mouseup', this.handleClick)
+  }
+
   // we added this to stop select events in case th e user clicks on the comment,
   // so it won't interfere with the context menu
   public stopEvent = (event: Event) => {
@@ -58,9 +64,6 @@ export class CitationEditableView extends CitationView {
     )
   }
 
-  public eventHandlers = () => {
-    this.dom.addEventListener('mouseup', this.handleClick)
-  }
   public handleClick = (event: MouseEvent) => {
     if (!this.can.seeReferencesButtons) {
       this.showPopper()

--- a/src/views/contributors.ts
+++ b/src/views/contributors.ts
@@ -32,7 +32,10 @@ import {
   authorLabel,
   ContributorAttrs,
 } from '../lib/authors'
-import { isDeleted } from '../lib/track-changes-utils'
+import {
+  addTrackChangesAttributes,
+  isDeleted,
+} from '../lib/track-changes-utils'
 import {
   deleteNode,
   findChildByID,
@@ -57,18 +60,7 @@ export class ContributorsView extends BlockView<Trackable<ContributorsNode>> {
   public ignoreMutation = () => true
   public stopEvent = () => true
 
-  public initialise = () => {
-    this.createDOM()
-    this.createGutter('block-gutter', this.gutterButtons().filter(Boolean))
-    this.createElement()
-    this.createGutter(
-      'action-gutter',
-      this.actionGutterButtons().filter(Boolean)
-    )
-    this.updateContents()
-  }
-
-  public updateContents = () => {
+  public updateContents() {
     const affs = affiliationsKey.getState(this.view.state)
     if (!affs) {
       return
@@ -129,12 +121,7 @@ export class ContributorsView extends BlockView<Trackable<ContributorsNode>> {
     container.setAttribute('id', attrs.id)
     container.setAttribute('contenteditable', 'false')
 
-    if (attrs.dataTracked?.length) {
-      const change = attrs.dataTracked[0]
-      container.setAttribute('data-track-id', change.id)
-      container.setAttribute('data-track-status', change.status)
-      container.setAttribute('data-track-op', change.operation)
-    }
+    addTrackChangesAttributes(attrs, container)
 
     const name = authorLabel(attrs)
     container.innerHTML =

--- a/src/views/creators.ts
+++ b/src/views/creators.ts
@@ -18,27 +18,9 @@ import { ManuscriptNode } from '@manuscripts/transform'
 
 import { Dispatch } from '../commands'
 import { EditorProps } from '../configs/ManuscriptsEditor'
+import { addTrackChangesAttributes } from '../lib/track-changes-utils'
 import { NodeViewCreator } from '../types'
-import { BaseNodeProps, BaseNodeView } from './base_node_view'
-
-export const createNodeView =
-  <T extends BaseNodeView<ManuscriptNode>, PropsT extends BaseNodeProps>(
-    type: new (...args: any[]) => T // eslint-disable-line @typescript-eslint/no-explicit-any
-  ) =>
-  (props: PropsT, dispatch?: Dispatch): NodeViewCreator<T> =>
-  (node, view, getPos, decorations) => {
-    const nodeView = new type(
-      { ...props, dispatch },
-      node,
-      view,
-      getPos,
-      decorations
-    )
-
-    nodeView.initialise()
-
-    return nodeView
-  }
+import { BaseNodeView } from './base_node_view'
 
 export const createEditableNodeView =
   <T extends BaseNodeView<ManuscriptNode>>(
@@ -58,6 +40,8 @@ export const createEditableNodeView =
 
     return nodeView
   }
+
+export const createNodeView = createEditableNodeView
 
 export const createNodeOrElementView =
   <T extends BaseNodeView<ManuscriptNode>>(
@@ -84,6 +68,10 @@ export const createNodeOrElementView =
     if (callback) {
       callback(node, dom)
     }
+    if (node.attrs.id) {
+      dom.id = node.attrs.id
+    }
+    addTrackChangesAttributes(node.attrs, dom)
 
     const nodeView = {
       dom,

--- a/src/views/cross_reference.ts
+++ b/src/views/cross_reference.ts
@@ -19,28 +19,16 @@ import {
   ManuscriptNodeView,
   Target,
 } from '@manuscripts/transform'
-import { Location, NavigateFunction } from 'react-router-dom'
 
-import { getChangeClasses } from '../lib/track-changes-utils'
 import { objectsKey } from '../plugins/objects'
 import { Trackable } from '../types'
-import { BaseNodeProps, BaseNodeView } from './base_node_view'
+import { BaseNodeView } from './base_node_view'
 import { createNodeView } from './creators'
-
-export interface CrossReferenceViewProps extends BaseNodeProps {
-  navigate: NavigateFunction
-  location: Location
-}
 
 export class CrossReferenceView
   extends BaseNodeView<Trackable<CrossReferenceNode>>
   implements ManuscriptNodeView
 {
-  public selectNode = () => {
-    // TODO: navigate to referenced item?
-    // TODO: show a list of referenced items?
-  }
-
   public handleClick = () => {
     const rids = this.node.attrs.rids
     if (!rids.length) {
@@ -52,11 +40,10 @@ export class CrossReferenceView
     })
   }
 
-  public updateContents = () => {
+  public updateContents() {
+    super.updateContents()
     const targets = objectsKey.getState(this.view.state) as Map<string, Target>
     const attrs = this.node.attrs
-    const classes = ['cross-reference', ...getChangeClasses(attrs.dataTracked)]
-    this.dom.className = classes.join(' ')
 
     const label = attrs.rids.length && targets.get(attrs.rids[0])?.label
     // attrs.label contains custom text inserted at cross-reference creation time

--- a/src/views/editable_block.ts
+++ b/src/views/editable_block.ts
@@ -38,12 +38,15 @@ export const EditableBlock = <T extends Constructor<BlockView<ManuscriptNode>>>(
   Base: T
 ) => {
   return class extends Base {
-    public gutterButtons = (): HTMLElement[] =>
-      [this.createAddButton(), this.createEditButton()].filter(isNotNull)
+    public gutterButtons() {
+      return [this.createAddButton(), this.createEditButton()].filter(isNotNull)
+    }
 
-    public actionGutterButtons = (): HTMLElement[] => []
+    public actionGutterButtons() {
+      return []
+    }
 
-    public createAddButton = (): HTMLElement | null => {
+    public createAddButton() {
       const hasAccess = this.props.getCapabilities()?.editArticle
       if (!hasAccess) {
         return null
@@ -74,7 +77,7 @@ export const EditableBlock = <T extends Constructor<BlockView<ManuscriptNode>>>(
       return button
     }
 
-    public createEditButton = (): HTMLElement | null => {
+    public createEditButton(): HTMLElement | null {
       if (!this.props.getCapabilities()?.editArticle) {
         return null
       }

--- a/src/views/equation.ts
+++ b/src/views/equation.ts
@@ -17,7 +17,6 @@
 import { EquationNode, ManuscriptNodeView } from '@manuscripts/transform'
 
 import { renderMath } from '../lib/math'
-import { getChangeClasses } from '../lib/track-changes-utils'
 import { Trackable } from '../types'
 import { BaseNodeView } from './base_node_view'
 import { createNodeView } from './creators'
@@ -33,16 +32,10 @@ export class EquationView
 
   public createDOM = () => {
     this.dom = document.createElement('div')
-    this.dom.setAttribute('id', this.node.attrs.id)
   }
 
-  public updateContents = () => {
-    const classes = [
-      'equation',
-      ...getChangeClasses(this.node.attrs.dataTracked),
-    ]
-    this.dom.className = classes.join(' ')
-
+  public updateContents() {
+    super.updateContents()
     this.dom.innerHTML = this.node.attrs.contents
     renderMath(this.dom)
   }

--- a/src/views/equation_element.ts
+++ b/src/views/equation_element.ts
@@ -24,18 +24,6 @@ export class EquationElementView extends BlockView<
   Trackable<EquationElementNode>
 > {
   public elementType = 'figure'
-
-  public updateContents = () => {
-    if (this.node.attrs.dataTracked?.length) {
-      const lastChange =
-        this.node.attrs.dataTracked[this.node.attrs.dataTracked.length - 1]
-      this.dom.setAttribute('data-track-status', lastChange.status)
-      this.dom.setAttribute('data-track-op', lastChange.operation)
-    } else {
-      this.dom.removeAttribute('data-track-status')
-      this.dom.removeAttribute('data-track-op')
-    }
-  }
 }
 
 export default createNodeView(EquationElementView)

--- a/src/views/figure.ts
+++ b/src/views/figure.ts
@@ -26,14 +26,15 @@ export class FigureView
 {
   protected container: HTMLElement
 
-  public initialise = () => {
+  public initialise() {
     this.createDOM()
     this.updateContents()
   }
 
   public ignoreMutation = () => true
 
-  public updateContents = () => {
+  public updateContents() {
+    super.updateContents()
     while (this.container.hasChildNodes()) {
       this.container.removeChild(this.container.firstChild as Node)
     }
@@ -66,9 +67,8 @@ export class FigureView
     return element
   }
 
-  protected createDOM = () => {
+  protected createDOM() {
     this.dom = document.createElement('figure')
-    this.dom.setAttribute('id', this.node.attrs.id)
 
     this.container = document.createElement('div')
     this.container.className = 'figure'

--- a/src/views/figure_editable.ts
+++ b/src/views/figure_editable.ts
@@ -15,7 +15,6 @@
  */
 
 import { FileCorruptedIcon } from '@manuscripts/style-guide'
-import { ManuscriptEditorView, ManuscriptNode } from '@manuscripts/transform'
 import { createElement } from 'react'
 import { renderToStaticMarkup } from 'react-dom/server'
 
@@ -32,34 +31,14 @@ import ReactSubView from './ReactSubView'
 export class FigureEditableView extends FigureView {
   public reactTools: HTMLDivElement
 
-  public viewProps: {
-    node: ManuscriptNode
-    getPos: () => number
-    view: ManuscriptEditorView
-  }
-
   public initialise = () => {
-    this.viewProps = {
-      node: this.node,
-      getPos: this.getPos,
-      view: this.view,
-    }
-
     this.createDOM()
     this.updateContents()
   }
 
-  public updateContents = () => {
+  public updateContents() {
+    super.updateContents()
     const attrs = this.node.attrs
-
-    if (this.node.attrs.dataTracked?.length) {
-      const change = this.node.attrs.dataTracked[0]
-      this.dom.setAttribute('data-track-status', change.status)
-      this.dom.setAttribute('data-track-op', change.operation)
-    } else {
-      this.dom.removeAttribute('data-track-status')
-      this.dom.removeAttribute('data-track-op')
-    }
 
     const src = attrs.src
     const files = this.props.getFiles()

--- a/src/views/figure_element.ts
+++ b/src/views/figure_element.ts
@@ -46,18 +46,10 @@ export class FigureElementView extends BlockView<Trackable<FigureElementNode>> {
     this.container.appendChild(this.contentDOM)
   }
 
-  public updateContents = () => {
+  public updateContents() {
+    super.updateContents()
     if (!this.contentDOM) {
       throw new Error('No contentDOM')
-    }
-
-    if (this.node.attrs.dataTracked?.length) {
-      const change = this.node.attrs.dataTracked[0]
-      this.dom.setAttribute('data-track-status', change.status)
-      this.dom.setAttribute('data-track-op', change.operation)
-    } else {
-      this.dom.removeAttribute('data-track-status')
-      this.dom.removeAttribute('data-track-op')
     }
 
     const can = this.props.getCapabilities()

--- a/src/views/footnote.ts
+++ b/src/views/footnote.ts
@@ -25,7 +25,7 @@ import {
 } from '../components/views/DeleteFootnoteDialog'
 import { alertIcon, deleteIcon } from '../icons'
 import { getFootnotesElementState } from '../lib/footnotes'
-import { getChangeClasses, isDeleted } from '../lib/track-changes-utils'
+import { isDeleted } from '../lib/track-changes-utils'
 import { Trackable } from '../types'
 import { BaseNodeView } from './base_node_view'
 import { createNodeView } from './creators'
@@ -36,12 +36,14 @@ export class FootnoteView extends BaseNodeView<Trackable<FootnoteNode>> {
 
   public initialise = () => {
     this.dom = document.createElement('div')
+    this.dom.classList.add('footnote')
     this.contentDOM = document.createElement('div')
     this.contentDOM.classList.add('footnote-text')
     this.updateContents()
   }
 
-  public updateContents = () => {
+  public updateContents() {
+    super.updateContents()
     const id = this.node.attrs.id
     const fn = getFootnotesElementState(this.view.state, id)
     if (!fn) {
@@ -63,9 +65,6 @@ export class FootnoteView extends BaseNodeView<Trackable<FootnoteNode>> {
     deleteBtn.addEventListener('mousedown', (e) => this.handleDeleteClick(e))
 
     this.dom.innerHTML = ''
-    this.dom.classList.value = ''
-    this.dom.classList.add('footnote')
-    this.dom.classList.add(...getChangeClasses(this.node.attrs.dataTracked))
     this.dom.appendChild(marker)
     this.contentDOM && this.dom.appendChild(this.contentDOM)
     this.dom.appendChild(deleteBtn)

--- a/src/views/footnotes_element.ts
+++ b/src/views/footnotes_element.ts
@@ -16,18 +16,19 @@
 
 import { FootnotesElementNode, ManuscriptNode } from '@manuscripts/transform'
 
-import { getChangeClasses } from '../lib/track-changes-utils'
 import BlockView from './block_view'
 import { createNodeOrElementView } from './creators'
 
 export class FootnotesElementView extends BlockView<FootnotesElementNode> {
   public elementType = 'div'
 
-  updateClasses = () => {
+  updateClasses() {
+    super.updateClasses()
     updateClasses(this.node, this.dom)
   }
 
-  onUpdateContent() {
+  updateContents() {
+    super.updateContents()
     this.checkEditability()
   }
 
@@ -44,7 +45,6 @@ export class FootnotesElementView extends BlockView<FootnotesElementNode> {
 const updateClasses = (node: ManuscriptNode, dom: HTMLElement) => {
   !node.childCount && dom.classList.add('empty-node')
   dom.classList.add('footnotes-element')
-  dom.classList.add(...getChangeClasses(node.attrs.dataTracked))
 }
 
 export default createNodeOrElementView(

--- a/src/views/general_table_footnote.ts
+++ b/src/views/general_table_footnote.ts
@@ -25,7 +25,7 @@ import {
   DeleteFootnoteDialogProps,
 } from '../components/views/DeleteFootnoteDialog'
 import { deleteIcon } from '../icons'
-import { getChangeClasses, isDeleted } from '../lib/track-changes-utils'
+import { isDeleted } from '../lib/track-changes-utils'
 import { Trackable } from '../types'
 import { BaseNodeView } from './base_node_view'
 import { createNodeView } from './creators'
@@ -38,21 +38,20 @@ export class GeneralTableFootnoteView extends BaseNodeView<
 
   public initialise = () => {
     this.dom = document.createElement('div')
+    this.dom.classList.add('footnote', 'general-table-footnote')
     this.contentDOM = document.createElement('div')
     this.contentDOM.classList.add('footnote-text')
     this.updateContents()
   }
 
-  public updateContents = () => {
+  public updateContents() {
+    super.updateContents()
     const deleteBtn = document.createElement('span')
     deleteBtn.classList.add('delete-icon')
     deleteBtn.innerHTML = deleteIcon
     deleteBtn.addEventListener('mousedown', (e) => this.handleClick(e))
 
     this.dom.innerHTML = ''
-    this.dom.classList.value = ''
-    this.dom.classList.add('footnote', 'general-table-footnote')
-    this.dom.classList.add(...getChangeClasses(this.node.attrs.dataTracked))
     this.contentDOM && this.dom.appendChild(this.contentDOM)
     this.dom.appendChild(deleteBtn)
   }

--- a/src/views/inline_equation.ts
+++ b/src/views/inline_equation.ts
@@ -17,7 +17,6 @@
 import { InlineEquationNode, ManuscriptNodeView } from '@manuscripts/transform'
 
 import { renderMath } from '../lib/math'
-import { getChangeClasses } from '../lib/track-changes-utils'
 import { Trackable } from '../types'
 import { BaseNodeView } from './base_node_view'
 import { createNodeView } from './creators'
@@ -26,26 +25,21 @@ export class InlineEquationView
   extends BaseNodeView<Trackable<InlineEquationNode>>
   implements ManuscriptNodeView
 {
-  public initialise = () => {
+  public initialise() {
     this.createDOM()
     this.updateContents()
   }
 
-  public updateContents = () => {
-    const classes = [
-      'equation',
-      ...getChangeClasses(this.node.attrs.dataTracked),
-    ]
-    this.dom.className = classes.join(' ')
+  public updateContents() {
     this.dom.innerHTML = this.node.attrs.contents
     renderMath(this.dom)
   }
 
   public ignoreMutation = () => true
 
-  protected createDOM = () => {
+  protected createDOM() {
     this.dom = document.createElement('span')
-    this.dom.setAttribute('id', this.node.attrs.id)
+    this.dom.classList.add('equation')
   }
 }
 

--- a/src/views/inline_footnote.ts
+++ b/src/views/inline_footnote.ts
@@ -32,11 +32,7 @@ import {
   findFootnotesContainerNode,
   getFootnotesElementState,
 } from '../lib/footnotes'
-import {
-  getChangeClasses,
-  isDeleted,
-  isPendingInsert,
-} from '../lib/track-changes-utils'
+import { isDeleted, isPendingInsert } from '../lib/track-changes-utils'
 import { Trackable } from '../types'
 import { BaseNodeView } from './base_node_view'
 import { createNodeView } from './creators'
@@ -140,12 +136,8 @@ export class InlineFootnoteView
     this.props.popper.show(this.dom, this.popperContainer, 'auto', false)
   }
 
-  public updateContents = () => {
-    this.dom.className = [
-      'footnote-marker',
-      ...getChangeClasses(this.node.attrs.dataTracked),
-    ].join(' ')
-
+  public updateContents() {
+    super.updateContents()
     const state = this.view.state
     const fn = getFootnotesElementState(state, this.node.attrs.id)
     if (!fn) {

--- a/src/views/keyword.ts
+++ b/src/views/keyword.ts
@@ -21,12 +21,12 @@ import {
   DeleteKeywordDialog,
   DeleteKeywordDialogProps,
 } from '../components/keywords/DeleteKeywordDialog'
-import { getChangeClasses } from '../lib/track-changes-utils'
 import { Trackable } from '../types'
 import { BaseNodeView } from './base_node_view'
 import { createNodeView } from './creators'
 import ReactSubView from './ReactSubView'
 
+//todo fix
 const deleteIcon =
   '<svg width="8px" height="8px" viewBox="0 0 26 26" xmlns="http://www.w3.org/2000/svg">\n' +
   '    <g stroke="none" stroke-width="1" fill="none" fill-rule="evenodd">\n' +
@@ -50,15 +50,12 @@ export class KeywordView
 
   public createDOM = () => {
     this.dom = document.createElement('span')
+    this.dom.classList.add('keyword')
     this.contentDOM = document.createElement('span')
   }
 
-  public updateContents = () => {
-    const classes = [
-      'keyword',
-      ...getChangeClasses(this.node.attrs.dataTracked),
-    ]
-    this.dom.className = classes.join(' ')
+  public updateContents() {
+    super.updateContents()
     this.dom.innerHTML = ''
     this.dom.appendChild(this.contentDOM as HTMLElement)
 
@@ -71,17 +68,6 @@ export class KeywordView
       svg.classList.add('delete-keyword')
       svg.addEventListener('click', this.showConfirmationDialog)
       this.dom.appendChild(svg)
-    }
-
-    if (this.node.attrs.dataTracked?.length) {
-      this.dom.setAttribute('data-track-id', this.node.attrs.dataTracked[0].id)
-      this.dom.setAttribute(
-        'data-track-status',
-        this.node.attrs.dataTracked[0].status
-      )
-    } else {
-      this.dom.removeAttribute('data-track-id')
-      this.dom.removeAttribute('data-track-status')
     }
   }
 

--- a/src/views/link_editable.ts
+++ b/src/views/link_editable.ts
@@ -22,7 +22,7 @@ import {
   LinkFormProps,
   LinkValue,
 } from '../components/views/LinkForm'
-import { getChangeClasses, isDeleted } from '../lib/track-changes-utils'
+import { isDeleted } from '../lib/track-changes-utils'
 import { allowedHref } from '../lib/url'
 import { createEditableNodeView } from './creators'
 import { LinkView } from './link'
@@ -38,15 +38,14 @@ export class LinkEditableView extends LinkView {
     this.updateContents()
   }
 
-  public updateContents = () => {
+  public updateContents() {
+    super.updateContents()
     this.contentDOM = this.dom
 
     const attrs = this.node.attrs
     const href = attrs.href
     const title = attrs.title
 
-    const classes = ['link', ...getChangeClasses(this.node.attrs.dataTracked)]
-    this.dom.className = classes.join(' ')
     this.dom.setAttribute('href', allowedHref(href) ? href : '')
     this.dom.setAttribute('target', '_blank')
     this.dom.setAttribute('title', title || '')
@@ -54,6 +53,7 @@ export class LinkEditableView extends LinkView {
 
   protected createDOM = () => {
     this.dom = document.createElement('a')
+    this.dom.classList.add('link')
     this.dom.addEventListener('click', this.handleClick)
   }
 

--- a/src/views/list.ts
+++ b/src/views/list.ts
@@ -28,25 +28,12 @@ import { EditableBlock } from './editable_block'
 export class ListView extends BlockView<Trackable<ListNode>> {
   public elementType = 'ul'
 
-  public updateContents = () => {
+  public updateContents() {
+    super.updateContents()
     const actualAttrs = this.node.attrs
     if (this.contentDOM) {
       const type = actualAttrs.listStyleType as JatsStyleType
       this.contentDOM.style.listStyleType = getListType(type).style
-    }
-
-    if (this.node.attrs.dataTracked?.length) {
-      this.dom.setAttribute(
-        'data-track-status',
-        this.node.attrs.dataTracked[0].status
-      )
-      this.dom.setAttribute(
-        'data-track-op',
-        this.node.attrs.dataTracked[0].operation
-      )
-    } else {
-      this.dom.removeAttribute('data-track-status')
-      this.dom.removeAttribute('data-track-op')
     }
   }
 }

--- a/src/views/list_item.ts
+++ b/src/views/list_item.ts
@@ -14,9 +14,8 @@
  * limitations under the License.
  */
 
-import { ListItemNode, ManuscriptNode } from '@manuscripts/transform'
+import { ListItemNode } from '@manuscripts/transform'
 
-import { getChangeClasses } from '../lib/track-changes-utils'
 import BlockView from './block_view'
 import { createNodeOrElementView } from './creators'
 
@@ -24,11 +23,4 @@ export class ListItemView extends BlockView<ListItemNode> {
   public elementType = 'li'
 }
 
-export const listItemCallback = (node: ManuscriptNode, dom: HTMLElement) => {
-  if (node.attrs.dataTracked) {
-    const classes = getChangeClasses(node.attrs.dataTracked)
-    dom.className = classes.join(' ')
-  }
-}
-
-export default createNodeOrElementView(ListItemView, 'li', listItemCallback)
+export default createNodeOrElementView(ListItemView, 'li')

--- a/src/views/ordered_list.ts
+++ b/src/views/ordered_list.ts
@@ -17,7 +17,6 @@
 import { ListElement } from '@manuscripts/json-schema'
 import { ListNode, ManuscriptNode } from '@manuscripts/transform'
 
-import { getChangeClasses } from '../lib/track-changes-utils'
 import { Trackable } from '../types'
 import BlockView from './block_view'
 import { createNodeOrElementView } from './creators'
@@ -39,30 +38,11 @@ export const JATS_HTML_LIST_STYLE_MAPPING: {
 export class OrderedListView extends BlockView<Trackable<ListNode>> {
   public elementType = 'ol'
 
-  public updateContents = () => {
+  public updateContents() {
+    super.updateContents()
     if (this.contentDOM) {
       const type = (this.node.attrs.listStyleType as JatsStyleType) || 'order'
       this.contentDOM.style.listStyleType = JATS_HTML_LIST_STYLE_MAPPING[type]
-
-      const classes = [
-        'block',
-        ...getChangeClasses(this.node.attrs.dataTracked),
-      ]
-
-      if (this.node.attrs.dataTracked) {
-        this.dom.setAttribute(
-          'data-track-status',
-          this.node.attrs.dataTracked[0].status
-        )
-        this.dom.setAttribute(
-          'data-track-op',
-          this.node.attrs.dataTracked[0].operation
-        )
-      } else {
-        this.dom.removeAttribute('data-track-status')
-        this.dom.removeAttribute('data-track-op')
-      }
-      this.contentDOM.className = classes.join(' ')
     }
   }
 }

--- a/src/views/section.ts
+++ b/src/views/section.ts
@@ -16,47 +16,45 @@
 
 import { SectionNode } from '@manuscripts/transform'
 
-import { PluginState, sectionTitleKey } from '../plugins/section_title'
+import { sectionTitleKey } from '../plugins/section_title'
 import BlockView from './block_view'
 import { createNodeView } from './creators'
 
-// handle sections numbering after track-changes process
-export const handleSectionNumbering = (sections: PluginState) => {
-  sections.forEach((sectionNumber, sectionId) => {
-    const section = document.getElementById(sectionId)
-    const sectionTitle = section?.querySelector('h1')
-    if (sectionTitle) {
-      sectionTitle.dataset.sectionNumber = sectionNumber
-    }
-  })
-}
 export class SectionView extends BlockView<SectionNode> {
   public elementType = 'section'
   public element: HTMLElement
-  public initialise = () => {
+
+  public initialise() {
     this.createDOM()
     this.createElement()
     this.updateContents()
   }
-  public createElement = () => {
+
+  public createElement() {
     this.contentDOM = document.createElement(this.elementType)
     this.dom.appendChild(this.contentDOM)
   }
-  public onUpdateContent = () => {
-    const sectionTitles = sectionTitleKey.getState(this.view.state)
 
-    const attrs = this.node.attrs
-    if (this.contentDOM) {
-      this.contentDOM.id = attrs.id
-      if (attrs.category) {
-        this.contentDOM.setAttribute('data-category', attrs.category)
+  public updateContents() {
+    super.updateContents()
+    this.dom.setAttribute('data-category', this.node.attrs.category)
+    this.handleSectionNumbering()
+  }
+
+  // handle sections numbering after track-changes process
+  //todo move to plugin
+  handleSectionNumbering() {
+    const sections = sectionTitleKey.getState(this.view.state)
+    if (!sections) {
+      return
+    }
+    sections.forEach((sectionNumber, id) => {
+      const section = document.getElementById(id)
+      const sectionTitle = section?.querySelector('h1')
+      if (sectionTitle) {
+        sectionTitle.dataset.sectionNumber = sectionNumber
       }
-    }
-
-    // update sections numbering, when newly inserted section got deleted
-    if (sectionTitles) {
-      handleSectionNumbering(sectionTitles)
-    }
+    })
   }
 }
 

--- a/src/views/section_title.ts
+++ b/src/views/section_title.ts
@@ -36,7 +36,8 @@ export class SectionTitleView extends BlockView<SectionTitleNode> {
     }
   }
 
-  public onUpdateContent = () => {
+  public updateContents() {
+    super.updateContents()
     const $pos = this.view.state.doc.resolve(this.getPos())
     const sectionTitleState = sectionTitleKey.getState(this.view.state)
     const parentSection = findParentNodeOfTypeClosestToPos(

--- a/src/views/table_cell.ts
+++ b/src/views/table_cell.ts
@@ -46,8 +46,9 @@ export class TableCellView extends BlockView<ManuscriptNode> {
     }
   }
 
-  public updateContents = () => {
+  public updateContents() {
     // will remove old attribute of node view as it could change rowspan,colspan from update to table
+    super.updateContents()
     this.dom.getAttributeNames().map((attr) => {
       if (attr !== 'class') {
         this.dom.removeAttribute(attr)

--- a/styles/Editor.css
+++ b/styles/Editor.css
@@ -1018,7 +1018,7 @@
   display: none;
 }
 
-.ProseMirror .graphical-abstract-figure.block-gutter {
+.ProseMirror .graphical-abstract .block-figure_element .block-gutter {
   visibility: hidden;
 }
 

--- a/yarn.lock
+++ b/yarn.lock
@@ -1574,10 +1574,10 @@
     "@manuscripts/json-schema" "2.2.10"
     citeproc "^2.4.62"
 
-"@manuscripts/style-guide@2.0.26":
-  version "2.0.26"
-  resolved "https://registry.yarnpkg.com/@manuscripts/style-guide/-/style-guide-2.0.26.tgz#02b4ce55f296f47e058ac0d9cec8c1cf49fa242b"
-  integrity sha512-qVyq3B3M6nR/5F4vFxWwvaYwrvF6ueZCrnkMXr2X2fbVHhSMjVgTcpdG0rDWcpJDZqDsvQYev2ZrVzXdmUeEIg==
+"@manuscripts/style-guide@2.0.27-LEAN-4199.0":
+  version "2.0.27-LEAN-4199.0"
+  resolved "https://registry.yarnpkg.com/@manuscripts/style-guide/-/style-guide-2.0.27-LEAN-4199.0.tgz#d50357057ecaaf65226f652166d99ce1308cd040"
+  integrity sha512-lAaYrEyvvef2vJMsD2OsG1MJ6tEB/96GpbvW7xj9oz9uh6BjS4kWXVnLckKVhkrnYuaF4yLUdq5JFBPD0snroA==
   dependencies:
     "@headlessui/react" "^2.1.10"
     "@manuscripts/json-schema" "2.2.11"

--- a/yarn.lock
+++ b/yarn.lock
@@ -1574,10 +1574,10 @@
     "@manuscripts/json-schema" "2.2.10"
     citeproc "^2.4.62"
 
-"@manuscripts/style-guide@2.0.27-LEAN-4199.0":
-  version "2.0.27-LEAN-4199.0"
-  resolved "https://registry.yarnpkg.com/@manuscripts/style-guide/-/style-guide-2.0.27-LEAN-4199.0.tgz#d50357057ecaaf65226f652166d99ce1308cd040"
-  integrity sha512-lAaYrEyvvef2vJMsD2OsG1MJ6tEB/96GpbvW7xj9oz9uh6BjS4kWXVnLckKVhkrnYuaF4yLUdq5JFBPD0snroA==
+"@manuscripts/style-guide@2.0.27":
+  version "2.0.27"
+  resolved "https://registry.yarnpkg.com/@manuscripts/style-guide/-/style-guide-2.0.27.tgz#b540e5c119581ee56c90c3361c79fd72ea3fbab1"
+  integrity sha512-H5cPTFam0sHAuw1pMQdL7Hfbpd90iMRjq8ZLsJDaWomDKsBHj2NhpiVleYQpWW2r4lWHrZY9t4av3YDvd5Euhg==
   dependencies:
     "@headlessui/react" "^2.1.10"
     "@manuscripts/json-schema" "2.2.11"


### PR DESCRIPTION
The main purpose of this PR is to have Track Changes related view logic applied for all views automatically. This includes:
- I changed all functions in `BaseNodeView` to be defined as _methods_ instead of function properties, which allows subclasses to call `super`.
- I updated the base `updateContents` to add the node id and the TC info into the DOM. For "element" views, I updated `createNodeOrElementView` to do the same.
- I updated all views to call `super.updateContents`.
- I removed most TC related logic from the views. The exception is some element views, which render multiple nodes (e.g. BibliographyElementView).

There are also a couple of small cleanups, not worth explicitly mentioning.