### PR TITLE
LEAN-4185 fix for tracking authors reordering

### DIFF
--- a/src/components/authors/AuthorsModal.tsx
+++ b/src/components/authors/AuthorsModal.tsx
@@ -49,6 +49,7 @@ import { AuthorFormPlaceholder } from './AuthorFormPlaceholder'
 import { AuthorList } from './AuthorList'
 import { RequiredFieldConfirmationDialog } from './RequiredFieldConfirmationDialog'
 import { SaveAuthorConfirmationDialog } from './SaveAuthorConfirmationDialog'
+import { cloneDeep } from 'lodash'
 
 const AddAuthorButton = styled.div`
   display: flex;
@@ -248,9 +249,9 @@ export const AuthorsModal: React.FC<AuthorsModalProps> = ({
   }
 
   const handleMoveAuthor = (from: number, to: number) => {
-    const copy = [...authors]
+    const copy = cloneDeep(authors)
     const order = copy.map((_, i) => (i === from ? to : i))
-    copy.sort((a, b) => order[authors.indexOf(a)] - order[authors.indexOf(b)])
+    copy.sort((a, b) => order[copy.indexOf(a)] - order[copy.indexOf(b)])
     copy.forEach((a, i) => {
       if (a.priority !== i) {
         a.priority = i


### PR DESCRIPTION
While we are still working on making author and affiliations reordering working correctly, there is no reason for authors reordering no to work as this is managed buy priority attribute. It just needs this priority assignment fix to enable it.