### PR TITLE
LEAN-4170: LW-FY25-Q3-S2: Deleting Pending Footnotes Without Pre-Note…

### DIFF
--- a/styles/Editor.css
+++ b/styles/Editor.css
@@ -1008,7 +1008,7 @@
   position: relative;
   border: 1px solid transparent;
 }
-.footnote .delete-icon {
+.ProseMirror .footnote .delete-icon {
   visibility: hidden;
 }
 .ProseMirror .footnote.footnote-selected:not(.inserted, .deleted) .delete-icon {

--- a/styles/Editor.css
+++ b/styles/Editor.css
@@ -963,7 +963,7 @@
   position: absolute;
   right: -20px;
   cursor: pointer;
-  z-index: 1;
+  z-index: 3;
 }
 .delete-icon svg path {
   fill: #c9c9c9;
@@ -1008,10 +1008,10 @@
   position: relative;
   border: 1px solid transparent;
 }
-.ProseMirror .footnote .delete-icon {
+.footnote .delete-icon {
   visibility: hidden;
 }
-.ProseMirror .footnote.footnote-selected .delete-icon {
+.ProseMirror .footnote.footnote-selected:not(.inserted, .deleted) .delete-icon {
   visibility: visible;
 }
 .ProseMirror .footnote .scroll-icon {


### PR DESCRIPTION
I have resolved the reported issue by hiding the delete icon for suggested footnotes, similar to how it is handled for keywords and other inserted suggestions in the editor. Since a footnote suggestion can be rejected, there is no need to allow deletion in such cases. Additionally, the delete button should not be accessible when the footnote is already deleted.