### PR TITLE
LEAN-4170: LW-FY25-Q3-S2: Deleting Pending Footnotes Without Pre-Note

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@manuscripts/body-editor",
   "description": "Prosemirror components for editing and viewing manuscripts",
-  "version": "2.7.36",
+  "version": "2.7.37-LEAN-4170-v0.0",
   "repository": "github:Atypon-OpenSource/manuscripts-body-editor",
   "license": "Apache-2.0",
   "main": "dist/cjs",

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@manuscripts/body-editor",
   "description": "Prosemirror components for editing and viewing manuscripts",
-  "version": "2.7.44",
+  "version": "2.7.45-LEAN-4170-v0.0",
   "repository": "github:Atypon-OpenSource/manuscripts-body-editor",
   "license": "Apache-2.0",
   "main": "dist/cjs",

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@manuscripts/body-editor",
   "description": "Prosemirror components for editing and viewing manuscripts",
-  "version": "2.7.36-LEAN-4170-v0.1",
+  "version": "2.7.36-LEAN-4170-v0.2",
   "repository": "github:Atypon-OpenSource/manuscripts-body-editor",
   "license": "Apache-2.0",
   "main": "dist/cjs",

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@manuscripts/body-editor",
   "description": "Prosemirror components for editing and viewing manuscripts",
-  "version": "2.7.36-LEAN-4170-v0.0",
+  "version": "2.7.36-LEAN-4170-v0.1",
   "repository": "github:Atypon-OpenSource/manuscripts-body-editor",
   "license": "Apache-2.0",
   "main": "dist/cjs",

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@manuscripts/body-editor",
   "description": "Prosemirror components for editing and viewing manuscripts",
-  "version": "2.7.31",
+  "version": "2.7.32-LEAN-4170-v0.0",
   "repository": "github:Atypon-OpenSource/manuscripts-body-editor",
   "license": "Apache-2.0",
   "main": "dist/cjs",

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@manuscripts/body-editor",
   "description": "Prosemirror components for editing and viewing manuscripts",
-  "version": "2.7.48",
+  "version": "2.7.49",
   "repository": "github:Atypon-OpenSource/manuscripts-body-editor",
   "license": "Apache-2.0",
   "main": "dist/cjs",

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@manuscripts/body-editor",
   "description": "Prosemirror components for editing and viewing manuscripts",
-  "version": "2.7.35",
+  "version": "2.7.36-LEAN-4170-v0.0",
   "repository": "github:Atypon-OpenSource/manuscripts-body-editor",
   "license": "Apache-2.0",
   "main": "dist/cjs",

--- a/src/views/footnote.ts
+++ b/src/views/footnote.ts
@@ -25,7 +25,7 @@ import {
 } from '../components/views/DeleteFootnoteDialog'
 import { alertIcon, deleteIcon, scrollIcon } from '../icons'
 import { getFootnotesElementState } from '../lib/footnotes'
-import { isDeleted } from '../lib/track-changes-utils'
+import { isDeleted, isPendingInsert } from '../lib/track-changes-utils'
 import { Trackable } from '../types'
 import { BaseNodeView } from './base_node_view'
 import { createNodeView } from './creators'
@@ -169,7 +169,11 @@ export class FootnoteView extends BaseNodeView<Trackable<FootnoteNode>> {
     )
     tr.delete(pos, pos + this.node.nodeSize)
 
-    if (element && getEffectiveChildCount(element.node) <= 1) {
+    if (
+      element &&
+      getEffectiveChildCount(element.node) <= 1 &&
+      !isPendingInsert(this.node)
+    ) {
       tr.delete(
         tr.mapping.map(element.pos),
         tr.mapping.map(element.pos + element.node.nodeSize)

--- a/src/views/footnote.ts
+++ b/src/views/footnote.ts
@@ -167,10 +167,13 @@ export class FootnoteView extends BaseNodeView<Trackable<FootnoteNode>> {
       $pos,
       schema.nodes.footnotes_element
     )
+    tr.delete(pos, pos + this.node.nodeSize)
+
     if (element && getEffectiveChildCount(element.node) <= 1) {
-      tr.delete(element.pos, element.pos + element.node.nodeSize)
-    } else {
-      tr.delete(pos, pos + this.node.nodeSize)
+      tr.delete(
+        tr.mapping.map(element.pos),
+        tr.mapping.map(element.pos + element.node.nodeSize)
+      )
     }
   }
 }

--- a/src/views/footnote.ts
+++ b/src/views/footnote.ts
@@ -90,7 +90,7 @@ export class FootnoteView extends BaseNodeView<Trackable<FootnoteNode>> {
         icon: 'Scroll',
       })
     }
-    if (can.editArticle) {
+    if (can.editArticle && !isDeleted(this.node)) {
       componentProps.actions.push({
         label: 'Delete',
         action: () => this.handleDelete(),

--- a/src/views/general_table_footnote.ts
+++ b/src/views/general_table_footnote.ts
@@ -70,11 +70,13 @@ export class GeneralTableFootnoteView extends BaseNodeView<
     const componentProps: ContextMenuProps = {
       actions: [],
     }
-    componentProps.actions.push({
-      label: 'Delete',
-      action: () => this.handleDeleteClick(),
-      icon: 'Delete',
-    })
+    if (!isDeleted(this.node)) {
+      componentProps.actions.push({
+        label: 'Delete',
+        action: () => this.handleDeleteClick(),
+        icon: 'Delete',
+      })
+    }
 
     this.contextMenu = ReactSubView(
       this.props,

--- a/styles/Editor.css
+++ b/styles/Editor.css
@@ -1018,7 +1018,7 @@
 .ProseMirror .footnote .delete-icon {
   visibility: hidden;
 }
-.ProseMirror .footnote.footnote-selected .delete-icon {
+.ProseMirror .footnote.footnote-selected:not(.deleted) .delete-icon {
   visibility: visible;
 }
 .ProseMirror .footnote .scroll-icon {

--- a/styles/Editor.css
+++ b/styles/Editor.css
@@ -1023,9 +1023,6 @@
 .ProseMirror .footnote .delete-icon {
   visibility: hidden;
 }
-.ProseMirror .footnote.footnote-selected:not(.deleted) .delete-icon {
-  visibility: visible;
-}
 .ProseMirror .footnote .scroll-icon {
   cursor: pointer;
   visibility: hidden;


### PR DESCRIPTION
This issue occurs when there is only one pending child/footnote. According to the current implementation, when you attempt to delete it, the tries to delete the footnote element, which is why it appears strikethrough but is not actually removed. Additionally, when inserting a new footnote, it is treated as part of the deleted footnote instead of being recognized as a new insertion, since the parent element is marked for deletion. However, when the delete suggestion is approved, the footnote is removed correctly.

This behavior does not occur in the scenario of an approved suggestion because the deletion is implemented in two stages: first, the child note is removed, and then, after approval, the footnote element is deleted. It seems that deleting a pending suggestion and its parent node simultaneously  is not functioning as intended. 

To resolve this, implement a two-stage deletion process for pending suggestions and prevent the simultaneous deletion of pending suggestions and parent node. First, ensure the child node is removed, then delete the footnote element upon approval. Additionally, map the position to ensure the footnote element's position is updated correctly after deleting the child node.

**Improvement**: Hide footnote delete icon for removed footnotes