### PR TITLE
Embed cleanup

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@manuscripts/body-editor",
   "description": "Prosemirror components for editing and viewing manuscripts",
-  "version": "2.7.35-embed-cleanup.0",
+  "version": "2.7.35",
   "repository": "github:Atypon-OpenSource/manuscripts-body-editor",
   "license": "Apache-2.0",
   "main": "dist/cjs",

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@manuscripts/body-editor",
   "description": "Prosemirror components for editing and viewing manuscripts",
-  "version": "2.7.34",
+  "version": "2.7.35-embed-cleanup.0",
   "repository": "github:Atypon-OpenSource/manuscripts-body-editor",
   "license": "Apache-2.0",
   "main": "dist/cjs",

--- a/src/lib/oembed.ts
+++ b/src/lib/oembed.ts
@@ -88,27 +88,29 @@ const globToRegex = (glob: string) => {
   return new RegExp(`^${regex}$`)
 }
 
-export const getOEmbedHTML = async (oembedUrl: string, sourceLink: string) => {
+export const getOEmbedHTML = async (
+  url: string,
+  width: number,
+  height: number
+) => {
   try {
-    const response = await fetch(oembedUrl)
+    const oembedUrl = await getOEmbedUrl(url, width, height)
+    if (!oembedUrl) {
+      return
+    }
 
+    const response = await fetch(oembedUrl)
     if (response.status === 200) {
-      const oembed = await response.json()
-      return oembed.html || renderAlternativeHTML(oembed, sourceLink)
-    } else {
-      return undefined
+      const json = await response.json()
+      return json.html || renderAlternativeHTML(json)
     }
   } catch (e) {
-    return undefined
+    return
   }
 }
 
-const renderAlternativeHTML = (oembed: ProviderJson, sourceLink: string) => {
+const renderAlternativeHTML = (oembed: ProviderJson) => {
   if (oembed.type === 'photo') {
     return `<img src="${oembed.url}">`
   }
-
-  return `<a href="${sourceLink}" target="_blank">${
-    oembed.title || 'Media link'
-  }</a>`
 }

--- a/src/views/embed.ts
+++ b/src/views/embed.ts
@@ -23,7 +23,7 @@ import {
   openEmbedDialog,
 } from '../components/toolbar/InsertEmbedDialog'
 import { openDeleteEmbedDialog } from '../components/views/DeleteEmbedDialog'
-import { getOEmbedHTML, getOEmbedUrl } from '../lib/oembed'
+import { getOEmbedHTML } from '../lib/oembed'
 import { Trackable } from '../types'
 import BlockView from './block_view'
 import { createNodeView } from './creators'
@@ -38,7 +38,6 @@ export class EmbedMediaView extends BlockView<Trackable<EmbedNode>> {
   public createElement = () => {
     this.container = document.createElement('div')
     this.container.classList.add('block')
-    this.container.setAttribute('id', this.node.attrs.id)
     this.dom.appendChild(this.container)
 
     this.contentDOM = document.createElement('div')
@@ -66,15 +65,12 @@ export class EmbedMediaView extends BlockView<Trackable<EmbedNode>> {
       this.container.prepend(preview)
     }
 
-    const oEmbedUrl = await getOEmbedUrl(this.href, 643, 363)
-    if (oEmbedUrl) {
-      const oembedHTML = await getOEmbedHTML(oEmbedUrl, this.href)
-      if (oembedHTML) {
-        preview.innerHTML = oembedHTML
-        return
-      }
+    const html = await getOEmbedHTML(this.href, 643, 363)
+    if (html) {
+      preview.innerHTML = html
+    } else {
+      this.showUnavailableMessage(preview)
     }
-    this.showUnavailableMessage(preview)
   }
 
   private buildContextMenu = (preview: HTMLElement) => {
@@ -100,7 +96,7 @@ export class EmbedMediaView extends BlockView<Trackable<EmbedNode>> {
         },
         {
           label: 'Edit',
-          action: () => openEmbedDialog(this.view, 'Update', this.getPos()),
+          action: () => openEmbedDialog(this.view, this.getPos()),
           icon: 'Edit',
         },
       ],


### PR DESCRIPTION
The main issue this PR tries to solve is debouncing; we're debouncing the _URL update_ which results in changes being dismissed when the user clicks on the "Update" quickly after changing the URL (e.g. during automated tests). Instead, we should be debouncing the HTML generation (which is the expensive part).

In addition, I simplified a couple of things, and added data-cy for testing.