### PR TITLE
LEAN-1939: LW - R7: New reference is added without being saved from t…

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@manuscripts/body-editor",
   "description": "Prosemirror components for editing and viewing manuscripts",
-  "version": "2.8.36",
+  "version": "2.8.37-LEAN-1939.0",
   "repository": "github:Atypon-OpenSource/manuscripts-body-editor",
   "license": "Apache-2.0",
   "main": "dist/cjs",

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@manuscripts/body-editor",
   "description": "Prosemirror components for editing and viewing manuscripts",
-  "version": "2.8.37-LEAN-1939.0",
+  "version": "2.8.37",
   "repository": "github:Atypon-OpenSource/manuscripts-body-editor",
   "license": "Apache-2.0",
   "main": "dist/cjs",

--- a/src/components/references/CitationEditor.tsx
+++ b/src/components/references/CitationEditor.tsx
@@ -117,7 +117,11 @@ export const CitationEditor: React.FC<CitationEditorProps> = ({
       type: 'update',
       items: [item],
     })
+    if (!rids.includes(item.id)) {
+      handleCite([item])
+    }
   }
+
   const handleDelete = (item: BibliographyItemAttrs) => {
     onDelete(item)
     dispatchItems({
@@ -161,8 +165,6 @@ export const CitationEditor: React.FC<CitationEditorProps> = ({
       id: generateID(ObjectTypes.BibliographyItem),
       type: 'article-journal',
     }
-    handleSave(item)
-    handleCite([item])
     setEditingForm({ show: true, item: item })
   }
 
@@ -182,6 +184,20 @@ export const CitationEditor: React.FC<CitationEditorProps> = ({
   const cited = useMemo(() => {
     return rids.flatMap((rid) => items.filter((i) => i.id === rid))
   }, [rids, items])
+
+  if (editingForm.show) {
+    return (
+      <ReferencesModal
+        isOpen={editingForm.show}
+        onCancel={() => setEditingForm({ show: false })}
+        items={items}
+        citationCounts={citationCounts}
+        item={editingForm.item}
+        onSave={handleSave}
+        onDelete={handleDelete}
+      />
+    )
+  }
 
   if (importing) {
     return (
@@ -264,15 +280,6 @@ export const CitationEditor: React.FC<CitationEditorProps> = ({
           </CitedItem>
         ))}
       </CitedItems>
-      <ReferencesModal
-        isOpen={editingForm.show}
-        onCancel={() => setEditingForm({ show: false })}
-        items={items}
-        citationCounts={citationCounts}
-        item={editingForm.item}
-        onSave={handleSave}
-        onDelete={handleDelete}
-      />
       <Actions>
         <IconTextButton />
         <ButtonGroup>

--- a/src/plugins/alt-titles.ts
+++ b/src/plugins/alt-titles.ts
@@ -13,6 +13,7 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
+import { skipTracking } from '@manuscripts/track-changes-plugin'
 import {
   AltTitleNode,
   AltTitlesSectionNode,
@@ -23,8 +24,8 @@ import {
 import { Node as ProseMirrorNode } from 'prosemirror-model'
 import { Plugin, PluginKey } from 'prosemirror-state'
 import { Decoration, DecorationSet } from 'prosemirror-view'
+
 import { arrowDown } from '../icons'
-import { skipTracking } from '@manuscripts/track-changes-plugin'
 
 export interface PluginState {
   collapsed: boolean


### PR DESCRIPTION
**issue** : When clicking "Add new" in CitationEditor, the handleAdd function immediately saved and cited the new reference before opening the ReferencesModal for editing. This caused the reference to be added to the bibliography and cited in the document even if the user canceled or closed the modal without saving.

**fix**: Modify handleAdd to defer saving and citing the new reference until the user explicitly saves it in the ReferencesModal.  and updated handleSave to cite the reference only when saved.

After removing handleCite from handleAdd, clicking "Add new" failed to open the ReferencesModal when rids.length was 0. This occurred because the rendering logic re-rendered ReferenceSearch (due to !rids.length) instead of showing the ReferencesModal, even though editingForm.show was set to true.