### PR TITLE
Replace `$from.node(-1`) with `findParentNodeOfType` for safer node traversal - LEAN-4572

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@manuscripts/body-editor",
   "description": "Prosemirror components for editing and viewing manuscripts",
-  "version": "2.8.65",
+  "version": "2.8.66-LEAN-4572.0",
   "repository": "github:Atypon-OpenSource/manuscripts-body-editor",
   "license": "Apache-2.0",
   "main": "dist/cjs",

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@manuscripts/body-editor",
   "description": "Prosemirror components for editing and viewing manuscripts",
-  "version": "2.8.69",
+  "version": "2.8.70",
   "repository": "github:Atypon-OpenSource/manuscripts-body-editor",
   "license": "Apache-2.0",
   "main": "dist/cjs",

--- a/src/commands.ts
+++ b/src/commands.ts
@@ -234,7 +234,7 @@ export const canInsert =
     }
 
     if (type === schema.nodes.table_element) {
-      if ($from.node(-1).type === schema.nodes.list_item) {
+      if (findParentNodeOfType(schema.nodes.list_item)(state.selection)) {
         return false
       }
     }


### PR DESCRIPTION
Replace `$from.node(-1) ` with `findParentNodeOfType`, which is more robust and correctly identifies the parent node of a given type regardless of its depth in the hierarchy. This change helps avoid structural assumptions and prevents potential bugs that arise from incorrect depth calculations.