### PR TITLE
The footnote marker disappears after refreshing the page (LEAN-4674)

### DIFF
--- a/src/plugins/footnotes.ts
+++ b/src/plugins/footnotes.ts
@@ -152,7 +152,7 @@ const buildFootnotesElementState = (
   inlineFootnotes.forEach(({ node, pos }) => {
     const inlineFootnote = node as InlineFootnoteNode
     const rids = inlineFootnote.attrs.rids
-    if (rids.length || rids.some((rid) => !footnoteIDs.has(rid))) {
+    if (!rids.length || rids.some((rid) => !footnoteIDs.has(rid))) {
       fn.updatedInlineFootnoteRids.push([
         node as InlineFootnoteNode,
         rids.filter((rid) => footnoteIDs.has(rid)),

--- a/src/plugins/footnotes.ts
+++ b/src/plugins/footnotes.ts
@@ -52,6 +52,11 @@ export type FootnotesElementState = {
    */
   unusedFootnoteIDs: Set<string>
   /**
+   * A list of inline_footnote nodes with rids that updated due to having a rid not
+   * referenced to footnote
+   */
+  updatedInlineFootnoteRids: [InlineFootnoteNode, string[], number][]
+  /**
    * A list of footnote nodes, in reference order. i.e. footnote nodes
    * that are referenced earlier appear earlier in the list.
    */
@@ -116,6 +121,7 @@ const buildFootnotesElementState = (
     element,
     inlineFootnotes: [],
     unusedFootnoteIDs: new Set(),
+    updatedInlineFootnoteRids: [],
     footnotes: [],
     labels: new Map(),
   }
@@ -147,6 +153,11 @@ const buildFootnotesElementState = (
     const inlineFootnote = node as InlineFootnoteNode
     const rids = inlineFootnote.attrs.rids
     if (rids.some((rid) => !footnoteIDs.has(rid))) {
+      fn.updatedInlineFootnoteRids.push([
+        node as InlineFootnoteNode,
+        rids.filter((rid) => footnoteIDs.has(rid)),
+        pos,
+      ])
       return
     }
     if (container[1]) {
@@ -232,6 +243,9 @@ export default (props: EditorProps) => {
         const footnotes = newState.footnotes.map(([node]) => node)
 
         if (hasChanged(newState, oldState)) {
+          newState.updatedInlineFootnoteRids.map(([node, rids, pos]) =>
+            tr.setNodeMarkup(pos, undefined, { ...node.attrs, rids })
+          )
           const newElement = schema.nodes.footnotes_element.create(
             element.attrs,
             // footnotes here is already in the correct order.


### PR DESCRIPTION
- Remove inline_footnote that has no footnote_element related to it, case of that rejection insert of `footnote_element`
- Remove inline_footnote with empty rids list