### PR TITLE
Issue with Paste elements from some out source (LEAN-4949)

### DIFF
--- a/src/clipboard.ts
+++ b/src/clipboard.ts
@@ -22,7 +22,7 @@ import { parseCssListStyleType } from './lib/lists'
 // to avoid having a conflict with manuscripts-transform
 const nodes = [
   {
-    tag: 'p',
+    tag: 'p, div',
     node: 'paragraph',
   },
   {


### PR DESCRIPTION
Currently `div` gets parsed as a [title node](https://github.com/Atypon-OpenSource/manuscripts-transform/blob/master/src/schema/nodes/title.ts#L38), update it to be a paragraph node