### PR TITLE
Let persist provide id's for manuscript node childs when missing - LEAN-5503

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@manuscripts/body-editor",
   "description": "Prosemirror components for editing and viewing manuscripts",
-  "version": "3.12.9-LEAN-5503.0",
+  "version": "3.12.9-LEAN-5503.1",
   "repository": "github:Atypon-OpenSource/manuscripts-body-editor",
   "license": "Apache-2.0",
   "main": "dist/cjs",

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@manuscripts/body-editor",
   "description": "Prosemirror components for editing and viewing manuscripts",
-  "version": "3.12.8",
+  "version": "3.12.9-LEAN-5503.0",
   "repository": "github:Atypon-OpenSource/manuscripts-body-editor",
   "license": "Apache-2.0",
   "main": "dist/cjs",

--- a/src/plugins/persist.ts
+++ b/src/plugins/persist.ts
@@ -44,8 +44,7 @@ export default () => {
         if (
           !(node.type.spec.attrs && 'id' in node.type.spec.attrs) ||
           isHighlightMarkerNode(node) ||
-          isManuscriptNode(node) ||
-          isManuscriptNode(parent)
+          isManuscriptNode(node)
         ) {
           return
         }


### PR DESCRIPTION
Problem:

The DOM id for the comment marker is built as ${key}-comment-marker, where key is the target node’s attrs.id.

For some top-level blocks (contributors, affiliations, keywords, awards—nodes that sit directly under the manuscript), attrs.id may be missing. In those cases, the marker key becomes empty, and the element ends up with id="-comment-marker", which is invalid/confusing and breaks things.

Solution:

Updated the persist plugin (responsible for assigning non-empty, unique ids) to stop skipping nodes whose parent is the manuscript node (isManuscriptNode(parent)).