### PR TITLE
Fix: Translations for Graphical Abstract & Key Image Abstract are not available - LEAN-5523

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@manuscripts/body-editor",
   "description": "Prosemirror components for editing and viewing manuscripts",
-  "version": "3.12.54",
+  "version": "3.12.55-LEAN-5523.0",
   "repository": "github:Atypon-OpenSource/manuscripts-body-editor",
   "license": "Apache-2.0",
   "main": "dist/cjs",

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@manuscripts/body-editor",
   "description": "Prosemirror components for editing and viewing manuscripts",
-  "version": "3.12.46",
+  "version": "3.12.47-LEAN-5523.0",
   "repository": "github:Atypon-OpenSource/manuscripts-body-editor",
   "license": "Apache-2.0",
   "main": "dist/cjs",

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@manuscripts/body-editor",
   "description": "Prosemirror components for editing and viewing manuscripts",
-  "version": "3.12.55-LEAN-5523.0",
+  "version": "3.12.55",
   "repository": "github:Atypon-OpenSource/manuscripts-body-editor",
   "license": "Apache-2.0",
   "main": "dist/cjs",

--- a/src/plugins/translations.ts
+++ b/src/plugins/translations.ts
@@ -125,7 +125,7 @@ export default (props: EditorProps) =>
             if (canEdit) {
               widgets.push(
                 Decoration.widget(
-                  pos + 2,
+                  pos + 1,
                   (view) => {
                     const $span = document.createElement('span')
                     $span.tabIndex = 0
@@ -158,7 +158,7 @@ export default (props: EditorProps) =>
                     )
                     return $span
                   },
-                  { key: `add-trans-${node.attrs.id || pos}`, side: -1 }
+                  { key: `add-trans-${node.attrs.id || pos}` }
                 )
               )
             }
@@ -177,7 +177,7 @@ export default (props: EditorProps) =>
 
             widgets.push(
               Decoration.widget(
-                pos + 2,
+                pos + 1,
                 (view) => {
                   const $btn = document.createElement('span')
                   $btn.className = 'language-selector-btn'
@@ -238,7 +238,7 @@ export default (props: EditorProps) =>
 
                   return $btn
                 },
-                { key: `lang-selector-${node.attrs.id}`, side: -1 }
+                { key: `lang-selector-${node.attrs.id}` }
               )
             )
           }

--- a/src/plugins/translations.ts
+++ b/src/plugins/translations.ts
@@ -169,7 +169,7 @@ export default (props: EditorProps) =>
                     )
                     return $span
                   },
-                  { key: `add-trans-${node.attrs.id || pos}` }
+                  { key: `add-trans-${node.attrs.id}-${pos}` }
                 )
               )
             }
@@ -250,7 +250,7 @@ export default (props: EditorProps) =>
                   return $btn
                 },
                 {
-                  key: `lang-selector-${node.attrs.id || pos}-${node.attrs.lang}`,
+                  key: `lang-selector-${node.attrs.id}-${pos}-${node.attrs.lang}`,
                 }
               )
             )

--- a/src/plugins/translations.ts
+++ b/src/plugins/translations.ts
@@ -238,7 +238,9 @@ export default (props: EditorProps) =>
 
                   return $btn
                 },
-                { key: `lang-selector-${node.attrs.id}` }
+                {
+                  key: `lang-selector-${node.attrs.id || pos}-${node.attrs.lang}`,
+                }
               )
             )
           }

--- a/src/plugins/translations.ts
+++ b/src/plugins/translations.ts
@@ -15,6 +15,7 @@
  */
 
 import { schema } from '@manuscripts/transform'
+import { Node } from 'prosemirror-model'
 import { Plugin } from 'prosemirror-state'
 import { Decoration, DecorationSet } from 'prosemirror-view'
 
@@ -89,6 +90,11 @@ const createLanguageMenu = (
   return { menu, destroy }
 }
 
+const getInsertionPos = (doc: Node, nodePos: number): number | null => {
+  const node = doc.nodeAt(nodePos)
+  return node ? nodePos + node.nodeSize : null
+}
+
 export default (props: EditorProps) =>
   new Plugin<null>({
     props: {
@@ -136,17 +142,22 @@ export default (props: EditorProps) =>
                     const handleActivate = (event: Event) => {
                       event.preventDefault()
                       event.stopPropagation()
+                      const insertPos = getInsertionPos(view.state.doc, pos)
+                      if (insertPos == null) {
+                        return
+                      }
                       if (isGraphical && category) {
-                        insertTransGraphicalAbstract(
-                          category,
-                          pos + node.nodeSize
-                        )(view.state, view.dispatch, view)
+                        insertTransGraphicalAbstract(category, insertPos)(
+                          view.state,
+                          view.dispatch,
+                          view
+                        )
                       } else {
                         insertTransAbstract(
                           view.state,
                           view.dispatch,
                           node.attrs.category,
-                          pos + node.nodeSize
+                          insertPos
                         )
                       }
                     }

--- a/styles/AdvancedEditor.css
+++ b/styles/AdvancedEditor.css
@@ -1880,11 +1880,23 @@ th:hover > .table-context-menu-button,
   position: relative;
 }
 
+/* Right padding so abstract titles do not run under translation widgets. 
+ * If we later block editing these titles, this padding can go away. 
+ */
+.ProseMirror .abstracts .block-section .block-section_title h1,
+.ProseMirror .abstracts .block-trans_abstract .block-section_title h1{
+  padding-right:  150px;
+}
+
 .ProseMirror .add-trans-abstract {
-  display: inline-flex;
+  display: flex;
   align-items: center;
-  float: right;
   gap: 8px;
+  margin: 8px 0;
+  padding: 6px 12px;
+  position: absolute;
+  right: 50px;
+  top: 0;
   z-index: 5;
   cursor: pointer;
   background: unset;
@@ -1920,13 +1932,18 @@ th:hover > .table-context-menu-button,
 }
 .ProseMirror .block-trans_abstract .language-selector-btn,
 .ProseMirror .block-trans_graphical_abstract .language-selector-btn {
-  display: inline-flex;
-  float: right;
+  display: flex;
+  position: absolute;
+  top: 14px;
+  right: 50px;
   line-height: 1.6;
   background: unset;
   border: none;
+  padding: 0;
+  margin: 0 6px;
   cursor: pointer;
   z-index: 10;
+  align-items: end;
   gap: 8px;
   font-size: 14px;
   color: #6e6e6e;

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -18,7 +18,7 @@
     "strict": true,
     "strictPropertyInitialization": false,
     "target": "es2020",
-    "types": ["vitest/globals", "csl"]
+    "types": ["vitest/globals", "csl", "node"]
   },
   "include": ["src"],
   "exclude": ["src/__mocks__"]


### PR DESCRIPTION
- Fix translations buttons pos. 
Reverting https://github.com/Atypon-OpenSource/manuscripts-body-editor/pull/880 and fixed the overlap issue in another way - not ideal but works specifically if we made these titles not editable - so overlapping won't happen and padding can go away.

- Fix widget key value.
- Fix stale node.nodeSize issue.