### PR TITLE
Section title is auto-populated in Graphical Abstract/Key Image translation (LEAN-5765)

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@manuscripts/body-editor",
   "description": "Prosemirror components for editing and viewing manuscripts",
-  "version": "3.13.10-LEAN-5765.0",
+  "version": "3.13.10",
   "repository": "github:Atypon-OpenSource/manuscripts-body-editor",
   "license": "Apache-2.0",
   "main": "dist/cjs",

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@manuscripts/body-editor",
   "description": "Prosemirror components for editing and viewing manuscripts",
-  "version": "3.13.9",
+  "version": "3.13.10-LEAN-5765.0",
   "repository": "github:Atypon-OpenSource/manuscripts-body-editor",
   "license": "Apache-2.0",
   "main": "dist/cjs",

--- a/src/commands.ts
+++ b/src/commands.ts
@@ -1456,7 +1456,7 @@ export const insertTransGraphicalAbstract =
         category: category.id,
       },
       [
-        schema.nodes.section_title.create({}, schema.text(category.titles[0])),
+        schema.nodes.section_title.create(),
         createAndFillFigureElement(state),
       ]
     ) as TransGraphicalAbstractNode

--- a/src/views/section_title.ts
+++ b/src/views/section_title.ts
@@ -29,7 +29,6 @@ export class SectionTitleView extends BlockView<SectionTitleNode> {
     schema.nodes.bibliography_section,
     schema.nodes.footnotes_section,
     schema.nodes.graphical_abstract_section,
-    schema.nodes.trans_graphical_abstract,
     schema.nodes.supplements,
   ]
 


### PR DESCRIPTION
In LEAN-5765 they want the translation section header to stay consistent with other abstract sections types
> Expected Result:
The title should remain empty (or follow the same behavior as other abstract types) until the user manually enters it, ensuring consistent behavior across all abstract sections.