### PR TITLE
LEAN-5935 - Unify react-router-dom on 6.30.0

### DIFF
--- a/package.json
+++ b/package.json
@@ -72,7 +72,7 @@
     "react-dnd-html5-backend": "16.0.1",
     "react-dom": "19.2.6",
     "react-is": "19.2.6",
-    "react-router-dom": "7.15.0",
+    "react-router-dom": "6.30.0",
     "react-select": "5.10.2",
     "styled-components": "6.4.2"
   },

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -126,8 +126,8 @@ importers:
         specifier: 19.2.6
         version: 19.2.6
       react-router-dom:
-        specifier: 7.15.0
-        version: 7.15.0(react-dom@19.2.6(react@19.2.6))(react@19.2.6)
+        specifier: 6.30.0
+        version: 6.30.0(react-dom@19.2.6(react@19.2.6))(react@19.2.6)
       react-select:
         specifier: 5.10.2
         version: 5.10.2(@types/react@19.2.17)(react-dom@19.2.6(react@19.2.6))(react@19.2.6)
@@ -988,6 +988,10 @@ packages:
 
   '@remirror/types@2.0.0':
     resolution: {integrity: sha512-j7G+hpyJ3SsZts0RpANYrTkQSWyP1+uy3txZPWgDwXGv3R45wtqRfoDzGO45vFcE9aNno/ThGPvClORZjjbrpw==}
+
+  '@remix-run/router@1.23.0':
+    resolution: {integrity: sha512-O3rHJzAQKamUz1fvE0Qaw0xSFqsA/yafi2iqeE0pvdFtCO1viYx8QL6f3Ln/aCCTLxs68SLf0KPM9eSeM8yBnA==}
+    engines: {node: '>=14.0.0'}
 
   '@rolldown/binding-android-arm64@1.1.3':
     resolution: {integrity: sha512-DT6Z3PhvioeHMvxo+xHc3KtqggrI7CCTXCmC2h/5zUlp5jVitv7XEy+9q5/7v8IolhlioawpMo8Kg0EEBy7J0g==}
@@ -1870,10 +1874,6 @@ packages:
 
   convert-source-map@2.0.0:
     resolution: {integrity: sha512-Kvp459HrV2FEJ1CAsi1Ku+MY3kasH19TFykTz2xWmMeq6bk2NU3XXvfJ+Q61m0xktWwt+1HSYf3JZsTms3aRJg==}
-
-  cookie@1.1.1:
-    resolution: {integrity: sha512-ei8Aos7ja0weRpFzJnEA9UHJ/7XQmqglbRwnf2ATjcB9Wq874VKH9kfjjirM6UhU2/E5fFYadylyhFldcqSidQ==}
-    engines: {node: '>=18'}
 
   core-util-is@1.0.3:
     resolution: {integrity: sha512-ZQBvi1DcpJ4GDqanjucZ2Hj3wEO5pZDS89BWbkcrvdxksJorwUDDZamX9ldFkp9aw2lmBDLgkObEA4DWNJ9FYQ==}
@@ -3889,27 +3889,23 @@ packages:
     peerDependencies:
       react: '>=15'
 
-  react-router-dom@7.15.0:
-    resolution: {integrity: sha512-VcrVg64Fo8nwBvDscajG8gRTLIuTC6N50nb22l2HOOV4PTOHgoGp8mUjy9wLiHYoYTSYI36tUnXZgasSRFZorQ==}
-    engines: {node: '>=20.0.0'}
+  react-router-dom@6.30.0:
+    resolution: {integrity: sha512-x30B78HV5tFk8ex0ITwzC9TTZMua4jGyA9IUlH1JLQYQTFyxr/ZxwOJq7evg1JX1qGVUcvhsmQSKdPncQrjTgA==}
+    engines: {node: '>=14.0.0'}
     peerDependencies:
-      react: '>=18'
-      react-dom: '>=18'
+      react: '>=16.8'
+      react-dom: '>=16.8'
 
   react-router@5.3.4:
     resolution: {integrity: sha512-Ys9K+ppnJah3QuaRiLxk+jDWOR1MekYQrlytiXxC1RyfbdsZkS5pvKAzCCr031xHixZwpnsYNT5xysdFHQaYsA==}
     peerDependencies:
       react: '>=15'
 
-  react-router@7.15.0:
-    resolution: {integrity: sha512-HW9vYwuM8f4yx66Izy8xfrzCM+SBJluoZcCbww9A1TySax11S5Vgw6fi3ZjMONw9J4gQwngL7PzkyIpJJpJ7RQ==}
-    engines: {node: '>=20.0.0'}
+  react-router@6.30.0:
+    resolution: {integrity: sha512-D3X8FyH9nBcTSHGdEKurK7r8OYE1kKFn3d/CF+CoxbSHkxU7o37+Uh7eAHRXr6k2tSExXYO++07PeXJtA/dEhQ==}
+    engines: {node: '>=14.0.0'}
     peerDependencies:
-      react: '>=18'
-      react-dom: '>=18'
-    peerDependenciesMeta:
-      react-dom:
-        optional: true
+      react: '>=16.8'
 
   react-select@5.10.2:
     resolution: {integrity: sha512-Z33nHdEFWq9tfnfVXaiM12rbJmk+QjFEztWLtmXqQhz6Al4UZZ9xc0wiatmGtUOCCnHN0WizL3tCMYRENX4rVQ==}
@@ -4081,9 +4077,6 @@ packages:
     resolution: {integrity: sha512-Y7/KDsb8LjooZpwaqGyulO6DQlksgCncchHGk+sZIY4SBvUocMBEFH5Ur1fI4dV+Jvl0w6cjvucaIi40puRioA==}
     engines: {node: '>=10'}
     hasBin: true
-
-  set-cookie-parser@2.7.2:
-    resolution: {integrity: sha512-oeM1lpU/UvhTxw+g3cIfxXHyJRc/uidd3yK1P242gzHds0udQBYzs3y8j4gCCW+ZJ7ad0yctld8RYO+bdurlvw==}
 
   set-function-length@1.2.2:
     resolution: {integrity: sha512-pgRc4hJ4/sNjWCSS9AmnS40x3bNMDTknHgL5UaMBTMyJnU90EgWh1Rz+MC9eFu4BuN/UwZjKQuY/1v3rM7HMfg==}
@@ -5820,6 +5813,8 @@ snapshots:
     dependencies:
       type-fest: 3.13.1
 
+  '@remix-run/router@1.23.0': {}
+
   '@rolldown/binding-android-arm64@1.1.3':
     optional: true
 
@@ -6714,8 +6709,6 @@ snapshots:
   convert-source-map@1.9.0: {}
 
   convert-source-map@2.0.0: {}
-
-  cookie@1.1.1: {}
 
   core-util-is@1.0.3: {}
 
@@ -9334,11 +9327,12 @@ snapshots:
       tiny-invariant: 1.3.3
       tiny-warning: 1.0.3
 
-  react-router-dom@7.15.0(react-dom@19.2.6(react@19.2.6))(react@19.2.6):
+  react-router-dom@6.30.0(react-dom@19.2.6(react@19.2.6))(react@19.2.6):
     dependencies:
+      '@remix-run/router': 1.23.0
       react: 19.2.6
       react-dom: 19.2.6(react@19.2.6)
-      react-router: 7.15.0(react-dom@19.2.6(react@19.2.6))(react@19.2.6)
+      react-router: 6.30.0(react@19.2.6)
 
   react-router@5.3.4(react@19.2.6):
     dependencies:
@@ -9353,13 +9347,10 @@ snapshots:
       tiny-invariant: 1.3.3
       tiny-warning: 1.0.3
 
-  react-router@7.15.0(react-dom@19.2.6(react@19.2.6))(react@19.2.6):
+  react-router@6.30.0(react@19.2.6):
     dependencies:
-      cookie: 1.1.1
+      '@remix-run/router': 1.23.0
       react: 19.2.6
-      set-cookie-parser: 2.7.2
-    optionalDependencies:
-      react-dom: 19.2.6(react@19.2.6)
 
   react-select@5.10.2(@types/react@19.2.17)(react-dom@19.2.6(react@19.2.6))(react@19.2.6):
     dependencies:
@@ -9586,8 +9577,6 @@ snapshots:
   semver@7.7.4: {}
 
   semver@7.8.5: {}
-
-  set-cookie-parser@2.7.2: {}
 
   set-function-length@1.2.2:
     dependencies:


### PR DESCRIPTION
## Summary

Across the manuscripts ecosystem, `react-router-dom` versions have drifted:

| Repo | Version |
|---|---|
| leanworkflow-dashboard | 6.30.0 |
| manuscripts-article-editor | 6.30.0 |
| manuscripts-body-editor (this repo) | ~~7.15.0~~ → **6.30.0** |
| manuscripts-style-guide | 5.3.4 (parallel companion PR bumping to 6.30.0) |

This PR downgrades body-editor's `react-router-dom` from `7.15.0` to the exact pin `6.30.0` to match the two majority/consumer repos (dashboard, article-editor). A companion PR in `manuscripts-style-guide` is bumping that repo's copy from `5.3.4` to `6.30.0` independently — not part of this change.

- `package.json`: `react-router-dom` `7.15.0` → `6.30.0` (exact pin)
- `pnpm-lock.yaml`: regenerated accordingly (react-router v7's `cookie`/`set-cookie-parser` deps swapped for v6's `@remix-run/router`)

### Usage audit

There are exactly 3 usages of `react-router-dom` in this repo's `src/`, all stable APIs identical between v6 and v7:

- `src/useEditor.ts` — `import { useLocation } from 'react-router-dom'`, used as `useLocation()`
- `src/configs/ManuscriptsEditor.ts` — `import { Location, NavigateFunction } from 'react-router-dom'`, used only as TS types
- `src/components/outline/Outline.tsx` — `import { Link } from 'react-router-dom'`, used as `styled(Link)`

None required changes — v6→v7 was designed as a low-friction bump for consumers using this subset of the API, and downgrading back to v6 needs no source changes here either.

No `@types/react-router-dom` devDependency exists (v6/v7 ship their own types), and there's no separate direct `react-router` entry — it's only pulled in transitively by `react-router-dom` itself.

### Known residual (expected, out of scope)

`pnpm why react-router-dom` currently shows two resolved versions:
- `react-router-dom@6.30.0` — our direct dependency (this PR)
- `react-router-dom@5.3.4` — transitive, via `@manuscripts/style-guide@3.7.1`'s own pinned dependency

This will collapse to a single `6.30.0` once the style-guide companion PR ships and a follow-up bumps body-editor's `@manuscripts/style-guide` dependency version — intentionally not done here since style-guide is being handled independently.

## Test plan

- [x] `grep -rn "react-router-dom" src/` — confirmed exactly the 3 usages listed above, all stable APIs
- [x] Confirmed no `@types/react-router-dom` devDependency and no separate `react-router` direct dependency
- [x] `pnpm install` — resolves cleanly, lockfile diff is small and surgical (just the react-router-dom/react-router version + dependency graph swap)
- [x] `pnpm typecheck` — passes (confirms `Location`/`NavigateFunction` types resolve identically from v6.30.0)
- [x] `pnpm test` — 6 test files / 19 tests pass
- [x] `pnpm lint` — passes with `--max-warnings=0`
- [x] `pnpm build` — cjs + es builds both succeed
- [x] `pnpm why react-router-dom` — resolves our own dependency to a single `6.30.0`; residual `5.3.4` is transitive via style-guide (see note above)
- [x] `git status`/diff reviewed — change is limited to `package.json` + `pnpm-lock.yaml`, no source changes needed

🤖 Generated with [Claude Code](https://claude.com/claude-code)